### PR TITLE
[WIP] Rebuild Sakura Checker score image pipeline

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,143 +1,32 @@
-// Amazon Display Sakura Checker - Background Service Worker
-// 機能モジュールを統合してサクラチェッカーAPIとの通信を担当
-
-console.log('Background Service Worker: 開始');
-
-// Service Worker として動作するため、importScripts を使用
-try {
-    importScripts(
-        'background/score-parser.js',
-        'background/api-client.js'
-    );
-    console.log('Background Service Worker: スクリプト読み込み完了');
-} catch (error) {
-    console.error('Background Service Worker: スクリプト読み込みエラー:', error);
-}
+importScripts("background/score-parser.js", "background/api-client.js");
 
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
-    console.log('Background Service Worker: メッセージ受信:', request);
-    
-    if (request.action === 'checkSakuraScore') {
-        console.log('Background Service Worker: サクラチェック要求受信:', {
-            productURL: request.productURL,
-            asin: request.asin,
-            timestamp: new Date().toISOString()
-        });
-        
-        console.log('Background Service Worker: Service Worker状態:', {
-            apiClientLoaded: !!self.ApiClient,
-            scoreParserLoaded: !!self.ScoreParser,
-            runtimeAvailable: !!chrome.runtime,
-            fetchAvailable: !!fetch
-        });
-        
-        // モジュールが読み込まれていることを確認
-        if (!self.ApiClient) {
-            console.error('Background Service Worker: ApiClientモジュールが読み込まれていません');
-            const errorResponse = { 
-                success: false, 
-                error: 'API通信モジュールが利用できません',
-                timestamp: new Date().toISOString()
-            };
-            console.log('Background Service Worker: エラーレスポンス送信:', errorResponse);
-            sendResponse(errorResponse);
-            return;
-        }
-        
-        console.log('Background Service Worker: ApiClient.checkSakuraScore呼び出し開始');
-        
-        // タイムアウト処理付きでAPIを呼び出し
-        const timeoutPromise = new Promise((_, reject) => {
-            setTimeout(() => {
-                console.error('Background Service Worker: API呼び出しタイムアウト（30秒）');
-                reject(new Error('サクラチェッカーAPIの応答がタイムアウトしました（30秒）'));
-            }, 30000);
-        });
-        
-        Promise.race([
-            self.ApiClient.checkSakuraScore(request.productURL, request.asin),
-            timeoutPromise
-        ])
-            .then(result => {
-                console.log('Background Service Worker: 処理完了:', result?.success ? 'success' : 'failed');
-                console.log('Background Service Worker: 結果詳細:', {
-                    success: result?.success,
-                    scoreRating: result?.scoreRating,
-                    sakuraPercentage: result?.sakuraPercentage,
-                    error: result?.error,
-                    timestamp: new Date().toISOString()
-                });
-                
-                try {
-                    sendResponse(result);
-                    console.log('Background Service Worker: レスポンス送信完了');
-                } catch (sendError) {
-                    console.error('Background Service Worker: レスポンス送信失敗:', sendError);
-                }
-            })
-            .catch(error => {
-                console.error('Background Service Worker: 処理エラー:', error);
-                console.error('Background Service Worker: エラースタック:', error.stack);
-                
-                const errorResponse = { 
-                    success: false,
-                    error: error.message,
-                    stack: error.stack,
-                    timestamp: new Date().toISOString()
-                };
-                
-                try {
-                    sendResponse(errorResponse);
-                    console.log('Background Service Worker: エラーレスポンス送信完了');
-                } catch (sendError) {
-                    console.error('Background Service Worker: エラーレスポンス送信失敗:', sendError);
-                }
-            });
-        
-        // 非同期レスポンスを有効化
-        return true;
-    }
-    
-    // デバッグ用のpingアクション
-    if (request.action === 'ping') {
-        console.log('Background Service Worker: pingメッセージ受信');
-        sendResponse({ 
-            pong: true, 
-            timestamp: new Date().toISOString(),
-            modules: {
-                apiClient: !!self.ApiClient,
-                scoreParser: !!self.ScoreParser
-            }
-        });
-        return;
-    }
-    
-    // デバッグ用のstatusアクション
-    if (request.action === 'status') {
-        console.log('Background Service Worker: statusメッセージ受信');
-        sendResponse({ 
-            status: 'active',
-            timestamp: new Date().toISOString(),
-            modules: {
-                apiClient: !!self.ApiClient,
-                scoreParser: !!self.ScoreParser,
-                fetch: !!fetch,
-                chrome: !!chrome
-            }
-        });
-        return;
-    }
-    
-    console.log('Background Service Worker: 不明なアクション:', request.action);
+  if (request?.action !== "checkSakuraScore") {
+    return false;
+  }
+
+  self.ApiClient.checkSakuraScore({
+    asin: request.asin,
+    amazonUrl: request.amazonUrl,
+    forceRefresh: Boolean(request.forceRefresh),
+  })
+    .then((result) => sendResponse(result))
+    .catch((error) => {
+      sendResponse({
+        ok: false,
+        code: "network_error",
+        message: error instanceof Error ? error.message : "Unexpected background error.",
+        sourceUrl: self.ApiClient.buildSourceUrl(request.asin),
+      });
+    });
+
+  return true;
 });
 
-// Service Worker のインストールとアクティベーション
-self.addEventListener('install', event => {
-    console.log('Background Service Worker: インストール完了');
-    self.skipWaiting();
+self.addEventListener("install", () => {
+  self.skipWaiting();
 });
 
-self.addEventListener('activate', event => {
-    console.log('Background Service Worker: アクティベーション完了');
-    event.waitUntil(self.clients.claim());
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
 });

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -1,388 +1,169 @@
-// API通信機能モジュール
-// sakura-checker.jpとの通信とリクエスト制御を管理
+(function (root, factory) {
+  const exportsObject = factory(
+    root.ScoreParser,
+    typeof module !== "undefined" && module.exports ? require("./score-parser.js") : null
+  );
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = exportsObject;
+  }
+  root.ApiClient = exportsObject;
+})(typeof self !== "undefined" ? self : globalThis, function (workerParser, nodeParser) {
+  const ScoreParser = workerParser || nodeParser;
+  const CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+  const FETCH_TIMEOUT_MS = 15000;
+  const CACHE_PREFIX = "score:";
 
-// リクエスト間隔制御のための変数
-let lastRequestTime = 0;
-const minRequestInterval = 2000; // 最小2秒間隔
+  function buildSourceUrl(asin) {
+    return `https://sakura-checker.jp/search/${asin}/`;
+  }
 
-// サクラチェッカーからサクラ度を取得する関数
-async function checkSakuraScore(productURL, asin) {
-    const timeoutMs = 20000; // 20秒タイムアウト
-    const maxRetries = 3; // 最大3回リトライ
-    
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-        try {
-            console.log(`Background Service Worker: サクラチェック開始 (${attempt + 1}/${maxRetries + 1}) - ASIN:`, asin);
-            console.log(`Background Service Worker: Service Worker状態:`, {
-                scriptURL: self.location ? self.location.href : 'unknown',
-                origin: self.origin || 'unknown',
-                currentTime: new Date().toISOString(),
-                fetchAvailable: typeof fetch !== 'undefined'
-            });
-            
-            // リクエスト間隔制御
-            const now = Date.now();
-            const timeSinceLastRequest = now - lastRequestTime;
-            if (timeSinceLastRequest < minRequestInterval) {
-                const waitTime = minRequestInterval - timeSinceLastRequest;
-                console.log(`Background Service Worker: リクエスト間隔調整のため${waitTime}ms待機`);
-                await new Promise(resolve => setTimeout(resolve, waitTime));
-            }
-            
-            // ランダムな追加遅延（1-3秒）でより自然なアクセスパターンを模倣
-            const randomDelay = Math.floor(Math.random() * 2000) + 1000;
-            console.log(`Background Service Worker: ランダム遅延 ${randomDelay}ms 実行中`);
-            await new Promise(resolve => setTimeout(resolve, randomDelay));
-            
-            lastRequestTime = Date.now();
-            
-            // sakura-checker.jpのURL構築（正しい形式：ASIN + スラッシュ）
-            const sakuraCheckerURL = `https://sakura-checker.jp/search/${asin}/`;
-            
-            console.log('Background Service Worker: 商品URL:', productURL);
-            console.log('Background Service Worker: ASIN:', asin);
-            console.log('Background Service Worker: リクエストURL:', sakuraCheckerURL);
-            console.log('Background Service Worker: fetchリクエスト開始:', {
-                method: 'GET',
-                timeout: timeoutMs,
-                timestamp: new Date().toISOString()
-            });
-            
-            // タイムアウト制御
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-            
-            const response = await fetch(sakuraCheckerURL, {
-                method: 'GET',
-                signal: controller.signal,
-                headers: {
-                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-                    'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
-                    'Accept-Encoding': 'gzip, deflate, br', // 通常のブラウザ動作に合わせる
-                    'Cache-Control': 'max-age=0',
-                    'Upgrade-Insecure-Requests': '1',
-                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                    'Referer': productURL  // リファラーを商品URLに設定
-                }
-            });
-            
-            clearTimeout(timeoutId);
-            
-            console.log('Background Service Worker: fetchレスポンス受信:', {
-                status: response.status,
-                statusText: response.statusText,
-                ok: response.ok,
-                url: response.url,
-                headers: Object.fromEntries(response.headers.entries()),
-                type: response.type,
-                redirected: response.redirected
-            });
-            
-            if (!response.ok) {
-                const errorMessage = `HTTP Error: ${response.status} ${response.statusText}`;
-                console.log('Background Service Worker: HTTPエラー詳細:', {
-                    status: response.status,
-                    statusText: response.statusText,
-                    url: sakuraCheckerURL,
-                    headers: Object.fromEntries(response.headers.entries())
-                });
-                
-                // 403エラーの場合は特別な処理
-                if (response.status === 403) {
-                    console.log('Background Script: 403エラー - Bot検出またはアクセス制限');
-                    
-                    // 403エラーの場合、より長い遅延でリトライ
-                    if (attempt < maxRetries) {
-                        const retryDelay = Math.floor(Math.random() * 5000) + 5000;
-                        console.log(`Background Script: 403エラーによりリトライ - ${retryDelay}ms後に再試行`);
-                        await new Promise(resolve => setTimeout(resolve, retryDelay));
-                        continue;
-                    }
-                }
-                
-                // サーバーエラーの場合はリトライ
-                if (response.status >= 500 && attempt < maxRetries) {
-                    console.log('Background Script: サーバーエラー、リトライします...');
-                    await new Promise(resolve => setTimeout(resolve, 1000 * (attempt + 1)));
-                    continue;
-                }
-                
-                throw new Error(errorMessage);
-            }
-            
-            // レスポンス文字エンコーディングの確認
-            const contentType = response.headers.get('content-type') || '';
-            const contentEncoding = response.headers.get('content-encoding') || '';
-            console.log('Background Script: レスポンスヘッダー情報:', {
-                contentType: contentType,
-                contentEncoding: contentEncoding,
-                charset: contentType.includes('charset=') ? contentType.split('charset=')[1] : 'なし'
-            });
-            
-            const html = await response.text();
-            console.log('Background Script: レスポンス受信完了', {
-                url: sakuraCheckerURL,
-                responseLength: html.length,
-                firstChars: html.substring(0, 100),
-                containsJapanese: /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(html),
-                containsHTML: html.includes('<html') || html.includes('<HTML'),
-                containsBody: html.includes('<body') || html.includes('<BODY')
-            });
-            
-            // レスポンスサイズチェック
-            if (html.length < 100) {
-                throw new Error('レスポンスが短すぎます（不正なレスポンス）');
-            }
-            
-            // 文字化けチェック
-            const isGarbled = !html.includes('<html') && !html.includes('<HTML') && 
-                             !html.includes('<body') && !html.includes('<BODY') &&
-                             !/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(html);
-            
-            if (isGarbled) {
-                console.log('Background Script: ⚠️ HTMLレスポンスが文字化けしている可能性があります');
-                console.log('Background Script: 文字化け検証情報:', {
-                    hasHTMLTag: html.includes('<html') || html.includes('<HTML'),
-                    hasBodyTag: html.includes('<body') || html.includes('<BODY'),
-                    hasJapanese: /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(html),
-                    firstByte: html.charCodeAt(0),
-                    secondByte: html.charCodeAt(1),
-                    thirdByte: html.charCodeAt(2)
-                });
-                
-                // 文字化けしている場合でも処理を続行（デバッグのため）
-                console.log('Background Script: 文字化けしたレスポンスでもスコア解析を試行します');
-            }
-            
-            // HTMLから2種類のスコアを抽出
-            console.log('Background Script: HTMLレスポンス受信完了、スコア解析開始');
-            
-            // 99%と1.24の存在チェック
-            const contains99 = html.includes('99%') || html.includes('99 %');
-            const contains124 = html.includes('1.24') || html.includes('1,24');
-            console.log('Background Script: 期待値存在チェック:', {
-                contains99Percent: contains99,
-                contains124Rating: contains124
-            });
-            
-            if (contains99) {
-                const match99 = html.match(/.{0,100}99\s*%.{0,100}/);
-                if (match99) {
-                    console.log('Background Script: 99%周辺HTML:', match99[0]);
-                }
-            }
-            
-            if (contains124) {
-                const match124 = html.match(/.{0,100}1\.24.{0,100}/);
-                if (match124) {
-                    console.log('Background Script: 1.24周辺HTML:', match124[0]);
-                }
-            }
-            
-            // Chrome拡張機能でのHTMLレスポンス詳細デバッグ
-            console.log('Background Script: Chrome拡張機能でのHTML解析詳細デバッグ開始');
-            console.log('Background Script: HTMLレスポンスの構造解析:');
-            console.log('Background Script: - HTML長さ:', html.length);
-            console.log('Background Script: - 最初の1000文字:', html.substring(0, 1000));
-            console.log('Background Script: - 中間1000文字:', html.substring(Math.floor(html.length/2), Math.floor(html.length/2) + 1000));
-            console.log('Background Script: - 最後の1000文字:', html.substring(html.length - 1000));
-            
-            // サクラチェッカー特有のセクション要素を探す
-            const sections = html.match(/<section[^>]*>/gi) || [];
-            console.log('Background Script: - section要素数:', sections.length);
-            
-            // item-ratingクラスを含む要素を検索
-            const itemRatingMatches = html.match(/<[^>]*class=[^>]*item-rating[^>]*>/gi) || [];
-            console.log('Background Script: - item-rating要素数:', itemRatingMatches.length);
-            
-            // サクラ度を含むsection要素を検索
-            const sakuraSections = html.match(/<section[^>]*>[\s\S]*?サクラ度[\s\S]*?<\/section>/gi) || [];
-            console.log('Background Script: - サクラ度section数:', sakuraSections.length);
-            
-            const scoreRating = self.ScoreParser ? self.ScoreParser.parseScoreRating(html) : null;
-            const sakuraPercentage = self.ScoreParser ? self.ScoreParser.parseSakuraPercentage(html) : null;
-            
-            console.log('Background Script: スコア解析結果:', {
-                scoreRating: scoreRating,
-                scoreRatingType: typeof scoreRating,
-                scoreRatingDetails: scoreRating,
-                sakuraPercentage: sakuraPercentage,
-                sakuraPercentageType: typeof sakuraPercentage
-            });
-            
-            // scoreRatingが画像オブジェクトかどうか詳細チェック
-            if (scoreRating && typeof scoreRating === 'object') {
-                console.log('Background Script: scoreRatingオブジェクト詳細:', {
-                    hasType: 'type' in scoreRating,
-                    type: scoreRating.type,
-                    hasImageData: 'imageData' in scoreRating,
-                    hasSuffix: 'suffix' in scoreRating,
-                    imageDataLength: scoreRating.imageData ? scoreRating.imageData.length : 0
-                });
-            }
-            
-            if (scoreRating !== null || sakuraPercentage !== null) {
-                console.log('Background Script: 少なくとも1つのスコアが取得できました');
-                return { 
-                    success: true, 
-                    scoreRating: scoreRating,
-                    sakuraPercentage: sakuraPercentage,
-                    asin: asin,
-                    timestamp: new Date().toISOString()
-                };
-            } else {
-                // 両方のスコアが見つからない場合、詳細なデバッグ情報を追加
-                console.log('Background Script: 全てのスコアの抽出に失敗 - 詳細デバッグ開始');
-                
-                // 基本HTML情報
-                const basicInfo = {
-                    htmlLength: html.length,
-                    containsSakura: html.includes('サクラ'),
-                    containsPercent: html.includes('%'),
-                    containsNumber: /\d/.test(html),
-                    containsImage: html.includes('<img'),
-                    imageMatches: html.match(/rv_level_s\d+\.png/g) || [],
-                    sPrefixImages: html.match(/s\d+\.png/g) || [],
-                    percentImages: html.match(/percent|%/gi) || []
-                };
-                console.log('Background Script: 基本HTML情報:', basicInfo);
-                
-                // より詳細なHTMLコンテンツ解析
-                const titleMatch = html.match(/<title[^>]*>([^<]*)</i);
-                const h1Match = html.match(/<h1[^>]*>([^<]*)</i);
-                console.log('Background Script: ページタイトル:', titleMatch ? titleMatch[1] : 'なし');
-                console.log('Background Script: H1要素:', h1Match ? h1Match[1] : 'なし');
-                
-                // HTML構造の詳細分析
-                const structureInfo = {
-                    pagetopElements: html.match(/id=["']pagetop["']/gi) || [],
-                    sectionElements: html.match(/<section[^>]*>/gi) || [],
-                    divElements: html.match(/<div[^>]*>/gi) || [],
-                    spanElements: html.match(/<span[^>]*>/gi) || [],
-                    pElements: html.match(/<p[^>]*>/gi) || [],
-                    imgElements: html.match(/<img[^>]*>/gi) || []
-                };
-                console.log('Background Script: HTML構造詳細:', {
-                    pagetopCount: structureInfo.pagetopElements.length,
-                    sectionCount: structureInfo.sectionElements.length,
-                    divCount: structureInfo.divElements.length,
-                    spanCount: structureInfo.spanElements.length,
-                    pCount: structureInfo.pElements.length,
-                    imgCount: structureInfo.imgElements.length
-                });
-                
-                // 画像ファイル名の詳細分析
-                const imageDetails = html.match(/<img[^>]*src="([^"]*)"[^>]*>/gi);
-                if (imageDetails && imageDetails.length > 0) {
-                    console.log('Background Script: 画像要素数:', imageDetails.length);
-                    const imageSources = imageDetails.map(img => {
-                        const srcMatch = img.match(/src="([^"]*)"/);
-                        return srcMatch ? srcMatch[1] : null;
-                    }).filter(src => src !== null);
-                    
-                    console.log('Background Script: 画像ソース（最初の10個）:', imageSources.slice(0, 10));
-                    
-                    // サクラチェッカー特有の画像パターンをチェック
-                    const sakuraImages = imageSources.filter(src => 
-                        src.includes('rv_level_s') || 
-                        src.includes('/s') || 
-                        src.includes('percent') ||
-                        /s\d+\.png/.test(src)
-                    );
-                    console.log('Background Script: サクラチェッカー画像パターン:', sakuraImages);
-                } else {
-                    console.log('Background Script: 画像要素が見つかりません');
-                }
-                
-                // section[4]やdiv[3]、div[4]などの特定要素をチェック
-                const specificElements = {
-                    section4: html.match(/<section[^>]*>[\s\S]*?<\/section>/gi),
-                    divWithClass: html.match(/<div[^>]*class="[^"]*"[^>]*>/gi) || [],
-                    spanWithContent: html.match(/<span[^>]*>[^<]*<\/span>/gi) || []
-                };
-                console.log('Background Script: 特定要素解析:', {
-                    section4Count: specificElements.section4 ? specificElements.section4.length : 0,
-                    divWithClassCount: specificElements.divWithClass.length,
-                    spanWithContentCount: specificElements.spanWithContent.length
-                });
-                
-                // HTMLサンプルを複数箇所から取得
-                const htmlSamples = {
-                    beginning: html.substring(0, 500),
-                    middle: html.substring(Math.floor(html.length / 2), Math.floor(html.length / 2) + 500),
-                    end: html.substring(html.length - 500)
-                };
-                console.log('Background Script: HTMLサンプル（開始500文字）:', htmlSamples.beginning);
-                console.log('Background Script: HTMLサンプル（中間500文字）:', htmlSamples.middle);
-                console.log('Background Script: HTMLサンプル（終了500文字）:', htmlSamples.end);
-                
-                return { 
-                    success: false, 
-                    error: 'スコアを取得できませんでした。商品が見つからないか、サクラチェッカーでの解析が完了していない可能性があります。', 
-                    asin: asin,
-                    debugInfo: {
-                        htmlLength: html.length,
-                        hasImages: html.includes('<img'),
-                        hasPercent: html.includes('%'),
-                        hasSakura: html.includes('サクラ'),
-                        title: titleMatch ? titleMatch[1] : null
-                    }
-                };
-            }
-            
-        } catch (error) {
-            console.error(`Background Service Worker: エラー (試行 ${attempt + 1}):`, {
-                name: error.name,
-                message: error.message,
-                stack: error.stack,
-                attempt: attempt + 1,
-                maxRetries: maxRetries + 1
-            });
-            
-            // 最後の試行でない場合はリトライ
-            if (attempt < maxRetries) {
-                const isNetworkError = error.name === 'AbortError' || error.name === 'TypeError';
-                const isServiceWorkerError = error.message.includes('Service Worker') || 
-                                           error.message.includes('context invalidated') ||
-                                           error.message.includes('terminated');
-                
-                if (isNetworkError || isServiceWorkerError) {
-                    const retryDelay = 1000 * (attempt + 1); // 指数バックオフ
-                    console.log(`Background Service Worker: ${isServiceWorkerError ? 'Service Worker' : 'ネットワーク'}エラー、${retryDelay}ms後にリトライします...`);
-                    await new Promise(resolve => setTimeout(resolve, retryDelay));
-                    continue;
-                }
-            }
-            
-            // エラーメッセージを分かりやすく変換
-            let errorMessage = error.message;
-            if (error.name === 'AbortError') {
-                errorMessage = 'リクエストがタイムアウトしました。ネットワーク接続を確認してください。';
-            } else if (error.name === 'TypeError' && error.message.includes('fetch')) {
-                errorMessage = 'ネットワークエラーが発生しました。インターネット接続を確認してください。';
-            } else if (error.message.includes('HTTP Error: 400')) {
-                errorMessage = 'リクエストが不正です。商品URLの形式に問題がある可能性があります。';
-            } else if (error.message.includes('HTTP Error: 403')) {
-                errorMessage = 'アクセスが制限されています。サクラチェッカーがBot検出を行っている可能性があります。しばらく時間をおいてから再試行してください。';
-            } else if (error.message.includes('HTTP Error: 404')) {
-                errorMessage = '商品が見つかりません。ASINが正しいか確認してください。';
-            } else if (error.message.includes('HTTP Error: 429')) {
-                errorMessage = 'アクセス制限により一時的に利用できません。しばらく待ってから再試行してください。';
-            } else if (error.message.includes('HTTP Error: 5')) {
-                errorMessage = 'サクラチェッカーのサーバーエラーです。しばらく待ってから再試行してください。';
-            }
-            
-            return { 
-                success: false, 
-                error: errorMessage, 
-                asin: asin,
-                retries: attempt + 1
-            };
-        }
+  function createFailure(code, message, sourceUrl) {
+    return { ok: false, code, message, sourceUrl };
+  }
+
+  function hasStorage() {
+    return (
+      typeof chrome !== "undefined" &&
+      chrome.storage &&
+      chrome.storage.local &&
+      typeof chrome.storage.local.get === "function"
+    );
+  }
+
+  function storageGet(key) {
+    if (!hasStorage()) {
+      return Promise.resolve(null);
     }
-}
 
-// エクスポート（Service Worker環境では self を使用）
-self.ApiClient = {
-    checkSakuraScore
-};
+    return new Promise((resolve) => {
+      chrome.storage.local.get([key], (result) => {
+        resolve(result[key] || null);
+      });
+    });
+  }
+
+  function storageSet(key, value) {
+    if (!hasStorage()) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ [key]: value }, () => resolve());
+    });
+  }
+
+  async function readCache(asin) {
+    const cacheKey = `${CACHE_PREFIX}${asin}`;
+    const cachedValue = await storageGet(cacheKey);
+    if (!cachedValue) {
+      return null;
+    }
+
+    const fetchedAt = Date.parse(cachedValue.fetchedAt);
+    if (Number.isNaN(fetchedAt) || Date.now() - fetchedAt > CACHE_TTL_MS) {
+      return null;
+    }
+
+    return cachedValue;
+  }
+
+  async function writeCache(asin, payload) {
+    const cacheKey = `${CACHE_PREFIX}${asin}`;
+    await storageSet(cacheKey, payload);
+  }
+
+  async function fetchSearchPage(asin, fetchImpl = fetch) {
+    const sourceUrl = buildSourceUrl(asin);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetchImpl(sourceUrl, {
+        method: "GET",
+        signal: controller.signal,
+        headers: {
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "ja,en-US;q=0.9,en;q=0.8",
+        },
+        cache: "no-store",
+      });
+
+      return { response, sourceUrl };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async function checkSakuraScore({ asin, forceRefresh = false, fetchImpl = fetch }) {
+    const sourceUrl = buildSourceUrl(asin);
+
+    if (!ScoreParser) {
+      return createFailure(
+        "parse_error",
+        "The score parser is not available in the background context.",
+        sourceUrl
+      );
+    }
+
+    if (!forceRefresh) {
+      const cachedValue = await readCache(asin);
+      if (cachedValue) {
+        return { ...cachedValue, cached: true };
+      }
+    }
+
+    let responseData = null;
+    try {
+      responseData = await fetchSearchPage(asin, fetchImpl);
+    } catch (error) {
+      const message =
+        error && error.name === "AbortError"
+          ? "Timed out while fetching Sakura Checker."
+          : "Failed to fetch Sakura Checker.";
+      return createFailure("network_error", message, sourceUrl);
+    }
+
+    const { response } = responseData;
+
+    if (response.status === 404) {
+      return createFailure("not_found", "The product was not found on Sakura Checker.", sourceUrl);
+    }
+    if (response.status === 403 || response.status === 429) {
+      return createFailure("blocked", "Sakura Checker temporarily blocked the request.", sourceUrl);
+    }
+    if (!response.ok) {
+      return createFailure(
+        "network_error",
+        `Unexpected response from Sakura Checker: ${response.status}.`,
+        sourceUrl
+      );
+    }
+
+    const html = await response.text();
+    const parsed = ScoreParser.parseVisualScore(html, asin);
+    if (!parsed.ok) {
+      return createFailure(parsed.code, parsed.message, sourceUrl);
+    }
+
+    const payload = {
+      ok: true,
+      cached: false,
+      fetchedAt: new Date().toISOString(),
+      sourceUrl,
+      score: parsed.score,
+    };
+
+    await writeCache(asin, payload);
+
+    return payload;
+  }
+
+  return {
+    buildSourceUrl,
+    checkSakuraScore,
+    createFailure,
+    fetchSearchPage,
+    readCache,
+    writeCache,
+  };
+});

--- a/background/score-parser.js
+++ b/background/score-parser.js
@@ -1,157 +1,257 @@
-// スコア解析機能モジュール
-// sakura-checker.jpから画像を直接抽出
+(function (root, factory) {
+  const exportsObject = factory();
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = exportsObject;
+  }
+  root.ScoreParser = exportsObject;
+})(typeof self !== "undefined" ? self : globalThis, function () {
+  const REVIEW_WRAP_MARKER = '<div class="item-review-wrap">';
+  const ITEM_BUTTON_MARKER = '<p class="item-btn">';
+  const ITEM_RATING_MARKER = '<p class="item-rating">';
 
-function extractScoreFromImages(html) {
-    try {
-        console.log('Background Script: base64画像からスコア抽出開始');
-        
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(html, 'text/html');
-        
-        let scoreImages = [];
-        let sakuraImages = [];
-        
-        const scoreSection = Array.from(doc.querySelectorAll('*')).find(el => 
-            el.textContent && el.textContent.includes('/5') && !el.textContent.includes('%')
-        );
-        
-        if (scoreSection) {
-            const scoreSpans = scoreSection.querySelectorAll('span');
-            for (const span of scoreSpans) {
-                const spanImages = span.querySelectorAll('img[src^="data:image/png;base64"]');
-                if (spanImages.length > 0 && span.textContent.includes('/5')) {
-                    const parentElement = span.parentElement;
-                    if (parentElement) {
-                        const allImages = parentElement.querySelectorAll('img[src^="data:image/png;base64"]');
-                        scoreImages = Array.from(allImages).map(img => ({
-                            src: img.src,
-                            alt: img.alt || '',
-                            fullUrl: img.src
-                        }));
-                        break;
-                    }
-                }
-            }
-            
-            if (scoreImages.length === 0) {
-                const base64Images = scoreSection.querySelectorAll('img[src^="data:image/png;base64"]');
-                console.log('Background Script: スコア評価セクション内の画像数:', base64Images.length);
-                
-                scoreImages = Array.from(base64Images).slice(0, 5).map(img => ({
-                    src: img.src,
-                    alt: img.alt || '',
-                    fullUrl: img.src
-                }));
-            }
-        }
-        
-        const sakuraSection = Array.from(doc.querySelectorAll('*')).find(el => 
-            el.textContent && el.textContent.includes('%') && el.textContent.includes('です。')
-        );
-        
-        if (sakuraSection) {
-            const sakuraSpans = sakuraSection.querySelectorAll('span');
-            for (const span of sakuraSpans) {
-                const spanImages = span.querySelectorAll('img[src^="data:image/png;base64"]');
-                if (spanImages.length > 0 && span.textContent.includes('%')) {
-                    sakuraImages = Array.from(spanImages).map(img => ({
-                        src: img.src,
-                        alt: img.alt || '',
-                        fullUrl: img.src
-                    }));
-                    break;
-                }
-            }
-            
-            if (sakuraImages.length === 0) {
-                const base64Images = sakuraSection.querySelectorAll('img[src^="data:image/png;base64"]');
-                console.log('Background Script: サクラ度セクション内の画像数:', base64Images.length);
-                
-                sakuraImages = Array.from(base64Images).slice(0, 2).map(img => ({
-                    src: img.src,
-                    alt: img.alt || '',
-                    fullUrl: img.src
-                }));
-            }
-        }
-        
-        console.log('Background Script: 抽出されたスコア評価画像:', scoreImages.length);
-        console.log('Background Script: 抽出されたサクラ度画像:', sakuraImages.length);
-        
-        return {
-            sakuraImages: sakuraImages,
-            scoreImages: scoreImages
-        };
-        
-    } catch (error) {
-        console.error('Background Script: 画像抽出エラー:', error);
-        return { sakuraImages: [], scoreImages: [] };
-    }
-}
+  function getReviewWrapRanges(html) {
+    const starts = [];
+    let startIndex = -1;
 
-// 複数の画像を組み合わせて表示用のHTMLを作成
-function createImageDisplayHTML(images, suffix) {
-    if (!images || images.length === 0) {
-        return null;
+    while ((startIndex = html.indexOf(REVIEW_WRAP_MARKER, startIndex + 1)) !== -1) {
+      starts.push(startIndex);
     }
-    
-    const imageElements = images.map(img => 
-        `<img src="${img.fullUrl}" style="display: inline-block; height: 16px; vertical-align: middle; margin: 0 1px;" alt="${img.alt}">`
-    ).join('');
-    
+
+    return starts.map((start, index) => {
+      const nextStart = starts[index + 1] ?? html.length;
+      const buttonIndex = html.indexOf(ITEM_BUTTON_MARKER, start);
+      const end =
+        buttonIndex !== -1 && buttonIndex < nextStart ? buttonIndex : nextStart;
+      return { start, end };
+    });
+  }
+
+  function findPrimaryProductBlock(html, asin) {
+    const markers = [
+      `https://www.amazon.co.jp/dp/${asin}`,
+      `https://www.amazon.co.jp/gp/product/${asin}`,
+      `/dp/${asin}`,
+      `/gp/product/${asin}`,
+    ];
+
+    for (const range of getReviewWrapRanges(html)) {
+      const block = html.slice(range.start, range.end);
+      if (markers.some((marker) => block.includes(marker))) {
+        return block;
+      }
+    }
+
+    return null;
+  }
+
+  function findRatingMarkup(block) {
+    const start = block.indexOf(ITEM_RATING_MARKER);
+    if (start === -1) {
+      return null;
+    }
+
+    const end = block.indexOf("</p>", start);
+    if (end === -1) {
+      return null;
+    }
+
+    return block.slice(start, end + 4);
+  }
+
+  function extractImageTags(markup) {
+    const tags = [];
+    let searchIndex = 0;
+
+    while (searchIndex < markup.length) {
+      const start = markup.indexOf("<img", searchIndex);
+      if (start === -1) {
+        break;
+      }
+
+      let inQuote = null;
+      let end = start;
+
+      for (; end < markup.length; end += 1) {
+        const character = markup[end];
+        if ((character === '"' || character === "'") && inQuote === null) {
+          inQuote = character;
+          continue;
+        }
+        if (character === inQuote) {
+          inQuote = null;
+          continue;
+        }
+        if (character === ">" && inQuote === null) {
+          break;
+        }
+      }
+
+      if (end >= markup.length) {
+        break;
+      }
+
+      tags.push(markup.slice(start, end + 1));
+      searchIndex = end + 1;
+    }
+
+    return tags;
+  }
+
+  function parseAttributes(tag) {
+    const attributes = {};
+    const attributePattern = /([^\s=/>]+)="([^"]*)"/g;
+    let match = null;
+
+    while ((match = attributePattern.exec(tag)) !== null) {
+      attributes[match[1]] = match[2];
+    }
+
+    return attributes;
+  }
+
+  function decodeBase64ToText(base64Text) {
+    if (typeof atob === "function") {
+      return atob(base64Text);
+    }
+
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(base64Text, "base64").toString("utf8");
+    }
+
+    throw new Error("No base64 decoder is available.");
+  }
+
+  function restoreObfuscatedValue(scrambled, insertLength, prefixLength) {
+    let n = insertLength;
+    const totalLength = scrambled.length;
+    const originalLength = totalLength - n;
+    let prefixStart = originalLength - prefixLength;
+
+    if (prefixStart < 0) {
+      prefixStart = 0;
+    }
+    if (prefixStart > originalLength) {
+      prefixStart = originalLength;
+    }
+    if (n > totalLength) {
+      n = totalLength;
+    }
+
+    let inserted = "";
+    let before = "";
+    let after = "";
+
+    if (originalLength >= 0 && prefixStart <= originalLength) {
+      inserted = scrambled.substr(prefixStart, n);
+      before = scrambled.substr(0, prefixStart);
+      after = scrambled.substr(prefixStart + n);
+    } else if (originalLength < 0 && totalLength > 0) {
+      inserted = scrambled.substr(0, n);
+    }
+
+    return inserted + before + after;
+  }
+
+  function decodeObfuscatedImageTag(tag) {
+    const attributes = parseAttributes(tag);
+    const onload = attributes.onload;
+
+    if (!onload) {
+      if (attributes.src && attributes.src.startsWith("data:image/")) {
+        return { src: attributes.src, alt: attributes.alt || "" };
+      }
+      return null;
+    }
+
+    const scrambledAttributeMatch = onload.match(
+      /var _[A-Za-z0-9]+=\s*this(?:\[[^\]]+\])+\('([^']+)'\)/
+    );
+    if (!scrambledAttributeMatch) {
+      return null;
+    }
+
+    const scrambledAttributeName = scrambledAttributeMatch[1];
+    const numericAssignments = Array.from(
+      onload
+        .slice(scrambledAttributeMatch.index)
+        .matchAll(/var _[A-Za-z0-9]+=(\d+);/g),
+      (match) => Number(match[1])
+    );
+
+    if (numericAssignments.length < 2) {
+      return null;
+    }
+
+    const scrambledValue = attributes[scrambledAttributeName];
+    if (!scrambledValue) {
+      return null;
+    }
+
+    const restoredBase64 = restoreObfuscatedValue(
+      scrambledValue,
+      numericAssignments[0],
+      numericAssignments[1]
+    );
+    const decodedSource = decodeBase64ToText(restoredBase64);
+
+    if (!decodedSource.startsWith("data:image/")) {
+      return null;
+    }
+
     return {
-        type: 'html',
-        htmlContent: imageElements + suffix,
-        suffix: suffix
+      src: decodedSource,
+      alt: attributes.alt || "",
     };
-}
+  }
 
-// n/5 形式のスコア解析関数（簡素化版）
-function parseScoreRating(html) {
-    try {
-        console.log('Background Script: n/5スコア解析開始');
-        
-        const imageData = extractScoreFromImages(html);
-        
-        if (imageData.scoreImages && imageData.scoreImages.length > 0) {
-            console.log('Background Script: スコア画像を返します');
-            return createImageDisplayHTML(imageData.scoreImages, '/5');
-        }
-        
-        console.log('Background Script: スコア画像が見つかりませんでした');
-        return null;
-        
-    } catch (error) {
-        console.error('Background Script: n/5スコア解析エラー:', error);
-        return null;
+  function parseVisualScore(html, asin) {
+    const productBlock = findPrimaryProductBlock(html, asin);
+    if (!productBlock) {
+      return {
+        ok: false,
+        code: "not_found",
+        message: `Could not find a Sakura Checker block for ASIN ${asin}.`,
+      };
     }
-}
 
-// n% 形式のサクラ度解析関数（簡素化版）
-function parseSakuraPercentage(html) {
-    try {
-        console.log('Background Script: n%サクラ度解析開始');
-        
-        const imageData = extractScoreFromImages(html);
-        
-        if (imageData.sakuraImages && imageData.sakuraImages.length > 0) {
-            console.log('Background Script: サクラ度画像を返します');
-            return createImageDisplayHTML(imageData.sakuraImages, '%');
-        }
-        
-        console.log('Background Script: サクラ度画像が見つかりませんでした');
-        return null;
-        
-    } catch (error) {
-        console.error('Background Script: n%サクラ度解析エラー:', error);
-        return null;
+    const ratingMarkup = findRatingMarkup(productBlock);
+    if (!ratingMarkup) {
+      return {
+        ok: false,
+        code: "parse_error",
+        message: "Could not locate the item-rating markup.",
+      };
     }
-}
 
-// エクスポート（Service Worker環境では self を使用）
-self.ScoreParser = {
-    extractScoreFromImages,
-    createImageDisplayHTML,
-    parseScoreRating,
-    parseSakuraPercentage
-};
+    const images = extractImageTags(ratingMarkup)
+      .map(decodeObfuscatedImageTag)
+      .filter(Boolean);
+
+    if (!images.length) {
+      return {
+        ok: false,
+        code: "parse_error",
+        message: "Could not decode the score images from the rating markup.",
+      };
+    }
+
+    return {
+      ok: true,
+      score: {
+        kind: "visual-image",
+        images,
+        suffix: "/5",
+      },
+    };
+  }
+
+  return {
+    decodeObfuscatedImageTag,
+    extractImageTags,
+    findPrimaryProductBlock,
+    findRatingMarkup,
+    parseAttributes,
+    parseVisualScore,
+    restoreObfuscatedValue,
+  };
+});

--- a/content.js
+++ b/content.js
@@ -1,112 +1,15 @@
-// Amazon Display Sakura Checker - Content Script (簡素版)
-// 機能モジュールを統合してサクラチェック結果を表示
+(function () {
+  function initialize() {
+    if (!window.SakuraChecker) {
+      return;
+    }
 
-(function() {
-    'use strict';
-    
-    console.log('Content Script: スクリプト読み込み開始');
-    console.log('Content Script: URL:', window.location.href);
-    console.log('Content Script: document.readyState:', document.readyState);
-    
-    // 処理中のASINを追跡して重複実行を防止
-    const processingASINs = new Set();
-    let isInitialized = false;
-    
-    // メイン処理（商品ページ専用）
-    function initialize() {
-        console.log('Content Script: 商品ページ初期化開始');
-        
-        // 重複初期化を防止
-        if (isInitialized) {
-            console.log('Amazon Display Sakura Checker: 既に初期化済みです');
-            return;
-        }
-        
-        // モジュールが読み込まれるまで待機
-        if (!window.AsinExtractor || !window.SakuraChecker) {
-            console.log('Content Script: モジュール読み込み待機中...');
-            setTimeout(initialize, 100);
-            return;
-        }
-        
-        // 商品ページ判定
-        if (!window.AsinExtractor.isProductPage()) {
-            console.log('Amazon Display Sakura Checker: 商品ページではありません');
-            return;
-        }
-        
-        // ASIN抽出
-        const asin = window.AsinExtractor.extractProductASIN();
-        if (!asin) {
-            console.log('Amazon Display Sakura Checker: 商品ASINを取得できませんでした');
-            return;
-        }
-        
-        console.log('Amazon Display Sakura Checker: 商品ASIN:', asin);
-        
-        // 初期化フラグを設定
-        isInitialized = true;
-        
-        // サクラチェック実行
-        const productURL = window.AsinExtractor.generateProductURL(asin);
-        window.SakuraChecker.checkSakuraScore(productURL, asin, processingASINs);
-    }
-    
-    // ページ読み込み完了後に実行
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initialize);
-    } else {
-        initialize();
-    }
-    
-    // 動的ページ変更への対応
-    const observer = new MutationObserver((mutations) => {
-        let shouldReinitialize = false;
-        
-        mutations.forEach((mutation) => {
-            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-                // 追加されたノードがサクラチェック結果でない場合のみ再初期化を検討
-                const hasNonSakuraNodes = Array.from(mutation.addedNodes).some(node => {
-                    if (node.nodeType === Node.ELEMENT_NODE) {
-                        // サクラチェック結果の要素は無視
-                        return !node.id?.includes('sakura-checker') && 
-                               !node.className?.includes('sakura-checker') &&
-                               !node.querySelector?.('#sakura-checker-result, .sakura-checker-wishlist-result');
-                    }
-                    return false;
-                });
-                
-                if (hasNonSakuraNodes) {
-                    shouldReinitialize = true;
-                }
-            }
-        });
-        
-        // URL変更を検出（SPAナビゲーション対応）
-        const currentURL = window.location.href;
-        if (observer.lastURL && observer.lastURL !== currentURL) {
-            console.log('Amazon Display Sakura Checker: URL変更を検出');
-            isInitialized = false;
-            processingASINs.clear();
-            shouldReinitialize = true;
-        }
-        observer.lastURL = currentURL;
-        
-        if (shouldReinitialize && !isInitialized) {
-            console.log('Amazon Display Sakura Checker: ページ変更により再初期化');
-            setTimeout(() => {
-                // 再初期化前にフラグをリセット
-                isInitialized = false;
-                initialize();
-            }, 1500);
-        }
-    });
-    
-    // 初期URL記録
-    observer.lastURL = window.location.href;
-    
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true
-    });
+    window.SakuraChecker.init();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initialize, { once: true });
+  } else {
+    initialize();
+  }
 })();

--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -1,77 +1,43 @@
-// ASIN抽出機能モジュール
-// Amazon商品ページからASINを抽出し、商品URLを生成する
-
-// 商品ASINを抽出する関数
-function extractProductASIN() {
-    // 1. URLからASINを抽出
-    const urlMatch = window.location.href.match(/\/dp\/([A-Z0-9]{10})|\/gp\/product\/([A-Z0-9]{10})/);
+(function () {
+  function extractProductASIN() {
+    const urlMatch = window.location.pathname.match(
+      /\/(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})/i
+    );
     if (urlMatch) {
-        return urlMatch[1] || urlMatch[2];
+      return urlMatch[1].toUpperCase();
     }
-    
-    // 2. meta要素からASINを抽出
-    const metaASIN = document.querySelector('meta[name="title"]');
-    if (metaASIN) {
-        const content = metaASIN.getAttribute('content');
-        const asinMatch = content.match(/([A-Z0-9]{10})/);
-        if (asinMatch) {
-            return asinMatch[1];
-        }
+
+    const canonical = document.querySelector('link[rel="canonical"]');
+    const canonicalHref = canonical && canonical.getAttribute("href");
+    if (canonicalHref) {
+      const canonicalMatch = canonicalHref.match(
+        /\/(?:dp|gp\/product)\/([A-Z0-9]{10})/i
+      );
+      if (canonicalMatch) {
+        return canonicalMatch[1].toUpperCase();
+      }
     }
-    
-    // 3. DOM要素からASINを抽出
-    const asinElement = document.querySelector('[data-asin]');
-    if (asinElement) {
-        const asin = asinElement.getAttribute('data-asin');
-        if (asin && asin.length === 10) {
-            return asin;
-        }
+
+    const dataAsin = document.querySelector("[data-asin]");
+    const asinValue = dataAsin && dataAsin.getAttribute("data-asin");
+    if (asinValue && /^[A-Z0-9]{10}$/i.test(asinValue)) {
+      return asinValue.toUpperCase();
     }
-    
+
     return null;
-}
+  }
 
-// 商品URLを生成する関数
-function generateProductURL(asin) {
-    // 現在のURLが既に適切な形式の場合はそのまま使用
-    const currentURL = window.location.href;
-    
-    // 現在のURLにASINが含まれている場合は、そのURLを使用
-    if (currentURL.includes(asin)) {
-        // URLのクエリパラメータやハッシュを除去してクリーンなURLにする
-        const url = new URL(currentURL);
-        const cleanURL = `${url.protocol}//${url.hostname}${url.pathname}`;
-        return cleanURL.endsWith('/') ? cleanURL.slice(0, -1) : cleanURL;
-    }
-    
-    // フォールバック: 標準的なdp/形式で生成
-    const currentDomain = window.location.hostname;
-    return `https://${currentDomain}/dp/${asin}`;
-}
+  function buildAmazonUrl(asin) {
+    return `https://www.amazon.co.jp/dp/${asin}`;
+  }
 
-// 商品ページかどうかを判定する関数
-function isProductPage() {
-    // URLパターンチェック
-    const urlPattern = /\/(dp|gp\/product)\/[A-Z0-9]{10}/;
-    if (urlPattern.test(window.location.pathname)) {
-        return true;
-    }
-    
-    // 商品ページの特徴的な要素の存在チェック
-    const productElements = [
-        '#productTitle',
-        '#priceblock_dealprice',
-        '#priceblock_ourprice',
-        '#add-to-cart-button',
-        '#buy-now-button'
-    ];
-    
-    return productElements.some(selector => document.querySelector(selector));
-}
+  function isProductPage() {
+    return Boolean(extractProductASIN());
+  }
 
-// エクスポート（グローバルスコープで利用可能にする）
-window.AsinExtractor = {
+  window.AsinExtractor = {
+    buildAmazonUrl,
     extractProductASIN,
-    generateProductURL,
-    isProductPage
-};
+    isProductPage,
+  };
+})();

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -1,125 +1,95 @@
-// サクラチェック通信機能モジュール
-// Background Scriptとの通信を管理する
+(function () {
+  class SakuraCheckerController {
+    constructor() {
+      this.currentAsin = null;
+      this.inFlight = false;
+    }
 
-// Background Scriptにサクラチェックを依頼する関数
-async function checkSakuraScore(productURL, asin, processingASINs) {
-    // 重複実行を防止
-    if (processingASINs.has(asin)) {
-        return;
+    init() {
+      this.refreshForCurrentPage(false);
+      this.observePageChanges();
     }
-    
-    // 既存の結果がある場合はスキップ
-    const existingResult = document.querySelector('#sakura-checker-result');
-    if (existingResult && !existingResult.textContent.includes('調査中') && !existingResult.textContent.includes('エラー')) {
+
+    async refreshForCurrentPage(forceRefresh) {
+      if (!window.AsinExtractor || !window.UiDisplay) {
         return;
-    }
-    
-    processingASINs.add(asin);
-    console.log('Amazon Display Sakura Checker: サクラチェック開始 - ASIN:', asin);
-    
-    try {
-        
-        // 読み込み中の表示を設定
-        if (window.UiDisplay) {
-            window.UiDisplay.displayLoadingResult();
+      }
+
+      if (!window.AsinExtractor.isProductPage()) {
+        window.UiDisplay.remove();
+        this.currentAsin = null;
+        return;
+      }
+
+      const asin = window.AsinExtractor.extractProductASIN();
+      if (!asin || this.inFlight) {
+        if (!asin) {
+          window.UiDisplay.remove();
+          this.currentAsin = null;
         }
-        
-        // Chrome拡張機能のランタイムが利用可能かチェック
-        if (!chrome.runtime || !chrome.runtime.sendMessage) {
-            throw new Error('Chrome拡張機能のランタイムが利用できません');
-        }
-        
-        // Service Workerの状態確認とメッセージ送信
-        console.log('Content Script: Background Service Workerにメッセージを送信中...', {
-            runtimeId: chrome.runtime.id,
-            productURL: productURL,
-            asin: asin
+        return;
+      }
+
+      this.currentAsin = asin;
+      this.inFlight = true;
+      window.UiDisplay.renderLoading();
+
+      try {
+        const response = await chrome.runtime.sendMessage({
+          action: "checkSakuraScore",
+          asin,
+          amazonUrl: window.AsinExtractor.buildAmazonUrl(asin),
+          forceRefresh: Boolean(forceRefresh),
         });
-        
-        let response;
-        console.log('Content Script: Service Workerへメッセージ送信中...', {
-            action: 'checkSakuraScore',
-            productURL: productURL,
-            asin: asin,
-            timestamp: new Date().toISOString()
-        });
-        
-        try {
-            response = await Promise.race([
-                chrome.runtime.sendMessage({
-                    action: 'checkSakuraScore',
-                    productURL: productURL,
-                    asin: asin
-                }),
-                new Promise((_, reject) => 
-                    setTimeout(() => {
-                        console.error('Content Script: タイムアウト発生 - Service Workerからの応答が45秒以内に来ませんでした');
-                        reject(new Error('Background Service Workerからの応答がタイムアウトしました'));
-                    }, 45000)
-                )
-            ]);
-            
-            console.log('Content Script: Background Service Workerからのレスポンス:', response);
-            console.log('Content Script: レスポンス詳細:', {
-                success: response?.success,
-                scoreRating: response?.scoreRating,
-                sakuraPercentage: response?.sakuraPercentage,
-                error: response?.error,
-                timestamp: new Date().toISOString()
-            });
-        } catch (error) {
-            // Service Workerが停止している可能性があるため、再試行
-            if (error.message.includes('Extension context invalidated') || 
-                error.message.includes('Could not establish connection')) {
-                console.warn('Content Script: Service Worker停止検出、再試行中...');
-                
-                // 短い遅延後に再試行
-                await new Promise(resolve => setTimeout(resolve, 1000));
-                
-                response = await chrome.runtime.sendMessage({
-                    action: 'checkSakuraScore',
-                    productURL: productURL,
-                    asin: asin
-                });
-                
-                console.log('Content Script: 再試行後のレスポンス:', response);
-            } else {
-                throw error;
-            }
+
+        if (asin !== this.currentAsin) {
+          return;
         }
-        
-        if (response?.success) {
-            if (window.UiDisplay) {
-                window.UiDisplay.displayDualScoreResult(response.scoreRating, response.sakuraPercentage, asin);
-            }
+
+        if (response && response.ok) {
+          window.UiDisplay.renderSuccess(response, () => this.refreshForCurrentPage(true));
         } else {
-            if (window.UiDisplay) {
-                window.UiDisplay.displayErrorResult(response?.error || 'スコアを取得できませんでした');
-            }
+          window.UiDisplay.renderError(response, () => this.refreshForCurrentPage(true));
         }
-        
-    } catch (error) {
-        console.error('Amazon Display Sakura Checker: 通信エラー:', error);
-        let errorMessage = '通信に失敗しました';
-        
-        if (error.message.includes('Extension context invalidated')) {
-            errorMessage = '拡張機能を再読み込みしてください';
-        } else if (error.message.includes('タイムアウト')) {
-            errorMessage = 'リクエストがタイムアウトしました';
-        } else if (error.message.includes('ランタイムが利用できません')) {
-            errorMessage = 'Chrome拡張機能として正しく読み込まれていません';
-        }
-        
-        if (window.UiDisplay) {
-            window.UiDisplay.displayErrorResult(errorMessage);
-        }
-    } finally {
-        // 処理完了時にASINを削除
-        processingASINs.delete(asin);
+      } catch (error) {
+        window.UiDisplay.renderError(
+          {
+            ok: false,
+            code: "network_error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to talk to the background service worker.",
+            sourceUrl: `https://sakura-checker.jp/search/${asin}/`,
+          },
+          () => this.refreshForCurrentPage(true)
+        );
+      } finally {
+        this.inFlight = false;
+      }
     }
-}
 
-// エクスポート（グローバルスコープで利用可能にする）
-window.SakuraChecker = {
-    checkSakuraScore
-};
+    observePageChanges() {
+      let previousUrl = window.location.href;
+      const observer = new MutationObserver(() => {
+        if (window.location.href !== previousUrl) {
+          previousUrl = window.location.href;
+          this.currentAsin = null;
+          this.refreshForCurrentPage(false);
+          return;
+        }
+
+        if (this.currentAsin && !document.getElementById("sakura-checker-result")) {
+          this.refreshForCurrentPage(false);
+        }
+      });
+
+      observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+
+  window.SakuraChecker = new SakuraCheckerController();
+})();

--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -1,475 +1,281 @@
-// UI表示機能モジュール
-// サクラチェック結果の表示とUI要素の管理
+(function () {
+  const ROOT_ID = "sakura-checker-result";
+  const STYLE_ID = "sakura-checker-style";
 
-// 読み込み中の表示を行う関数
-function displayLoadingResult() {
-    // 既存の結果要素を削除
-    const existingResult = document.querySelector('#sakura-checker-result');
-    if (existingResult) {
-        existingResult.remove();
+  function ensureStyles() {
+    if (document.getElementById(STYLE_ID)) {
+      return;
     }
-    
-    // 読み込み中表示要素を作成
-    const loadingElement = createLoadingElement();
-    
-    // 挿入位置を特定
-    const insertionPoint = findInsertionPoint();
-    
-    if (insertionPoint) {
-        insertionPoint.insertAdjacentElement('afterend', loadingElement);
-    } else {
-        document.body.insertAdjacentElement('afterbegin', loadingElement);
-    }
-}
 
-// 読み込み中要素を作成する関数
-function createLoadingElement() {
-    const loadingDiv = document.createElement('div');
-    loadingDiv.id = 'sakura-checker-result';
-    
-    loadingDiv.innerHTML = `
-        <div style="
-            background-color: #f8f9fa;
-            border: 2px solid #6c757d;
-            border-radius: 8px;
-            padding: 12px;
-            margin: 10px 0;
-            font-family: 'Arial', sans-serif;
-            font-size: 14px;
-            line-height: 1.4;
-            color: #333;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            position: relative;
-            z-index: 1000;
-        ">
-            <div style="
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                margin-bottom: 8px;
-            ">
-                <span style="
-                    background-color: #6c757d;
-                    color: white;
-                    padding: 4px 8px;
-                    border-radius: 4px;
-                    font-weight: bold;
-                    font-size: 12px;
-                ">
-                    🌸 サクラチェック
-                </span>
-                <span style="
-                    font-size: 14px;
-                    color: #6c757d;
-                ">
-                    調査中...
-                </span>
-            </div>
-            <div style="
-                font-size: 13px;
-                color: #555;
-                margin-bottom: 8px;
-            ">
-                サクラ度を調査しています。しばらくお待ちください。
-            </div>
-            <div style="
-                font-size: 11px;
-                color: #999;
-                text-align: right;
-            ">
-                Powered by sakura-checker.jp
-            </div>
-        </div>
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${ROOT_ID} {
+        border: 1px solid #d5d9d9;
+        border-left: 4px solid #f08804;
+        border-radius: 8px;
+        background: #ffffff;
+        padding: 16px;
+        margin: 12px 0;
+        box-shadow: 0 1px 3px rgba(15, 17, 17, 0.08);
+        color: #0f1111;
+        font-family: "Hiragino Sans", "Yu Gothic", sans-serif;
+      }
+
+      #${ROOT_ID} .sc-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 10px;
+      }
+
+      #${ROOT_ID} .sc-badge {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        background: #232f3e;
+        color: #ffffff;
+        font-size: 12px;
+        font-weight: 700;
+        padding: 4px 10px;
+      }
+
+      #${ROOT_ID} .sc-status {
+        font-size: 13px;
+        color: #565959;
+      }
+
+      #${ROOT_ID} .sc-score {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-height: 28px;
+        margin-bottom: 10px;
+      }
+
+      #${ROOT_ID} .sc-score img {
+        max-height: 28px;
+        width: auto;
+        display: block;
+      }
+
+      #${ROOT_ID} .sc-suffix {
+        font-size: 18px;
+        font-weight: 700;
+        color: #0f1111;
+      }
+
+      #${ROOT_ID} .sc-message {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #0f1111;
+      }
+
+      #${ROOT_ID} .sc-meta {
+        font-size: 12px;
+        color: #565959;
+        margin-top: 8px;
+      }
+
+      #${ROOT_ID} .sc-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      #${ROOT_ID} .sc-button,
+      #${ROOT_ID} .sc-link {
+        appearance: none;
+        border: 1px solid #d5d9d9;
+        border-radius: 999px;
+        background: #ffffff;
+        color: #0f1111;
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 700;
+        padding: 7px 12px;
+        text-decoration: none;
+      }
+
+      #${ROOT_ID} .sc-button:hover,
+      #${ROOT_ID} .sc-link:hover {
+        background: #f7fafa;
+      }
+
+      #${ROOT_ID}[data-state="error"] {
+        border-left-color: #b12704;
+      }
+
+      #${ROOT_ID}[data-state="loading"] {
+        border-left-color: #007185;
+      }
     `;
-    
-    return loadingDiv;
-}
 
-// エラー表示を行う関数
-function displayErrorResult(errorMessage) {
-    // 既存の結果要素を削除
-    const existingResult = document.querySelector('#sakura-checker-result');
-    if (existingResult) {
-        existingResult.remove();
+    document.head.appendChild(style);
+  }
+
+  function findInsertionPoint() {
+    return (
+      document.querySelector("#title_feature_div") ||
+      document.querySelector("#titleSection") ||
+      document.querySelector("#centerCol") ||
+      document.querySelector("#ppd")
+    );
+  }
+
+  function ensureRoot() {
+    ensureStyles();
+
+    let root = document.getElementById(ROOT_ID);
+    if (root && document.contains(root)) {
+      return root;
     }
-    
-    // エラー表示要素を作成
-    const errorElement = createErrorElement(errorMessage);
-    
-    // 挿入位置を特定
+
+    root = document.createElement("section");
+    root.id = ROOT_ID;
+
     const insertionPoint = findInsertionPoint();
-    
-    if (insertionPoint) {
-        insertionPoint.insertAdjacentElement('afterend', errorElement);
-    } else {
-        document.body.insertAdjacentElement('afterbegin', errorElement);
+    if (insertionPoint && insertionPoint.parentNode) {
+      insertionPoint.insertAdjacentElement("afterend", root);
+    } else if (document.body) {
+      document.body.insertAdjacentElement("afterbegin", root);
     }
-}
 
-// エラー要素を作成する関数
-function createErrorElement(errorMessage) {
-    const errorDiv = document.createElement('div');
-    errorDiv.id = 'sakura-checker-result';
-    
-    errorDiv.innerHTML = `
-        <div style="
-            background-color: #fff3cd;
-            border: 2px solid #ffc107;
-            border-radius: 8px;
-            padding: 12px;
-            margin: 10px 0;
-            font-family: 'Arial', sans-serif;
-            font-size: 14px;
-            line-height: 1.4;
-            color: #333;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            position: relative;
-            z-index: 1000;
-        ">
-            <div style="
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                margin-bottom: 8px;
-            ">
-                <span style="
-                    background-color: #ffc107;
-                    color: #212529;
-                    padding: 4px 8px;
-                    border-radius: 4px;
-                    font-weight: bold;
-                    font-size: 12px;
-                ">
-                    ⚠️ サクラチェック
-                </span>
-                <span style="
-                    font-size: 14px;
-                    color: #856404;
-                ">
-                    エラー
-                </span>
-            </div>
-            <div style="
-                font-size: 13px;
-                color: #555;
-                margin-bottom: 8px;
-            ">
-                ${errorMessage}
-            </div>
-            <div style="
-                font-size: 11px;
-                color: #999;
-                text-align: right;
-            ">
-                Powered by sakura-checker.jp
-            </div>
-        </div>
-    `;
-    
-    return errorDiv;
-}
+    return root;
+  }
 
-// 両方のスコアを表示する関数
-function displayDualScoreResult(scoreRating, sakuraPercentage, asin) {
-    console.log('Amazon Display Sakura Checker: 両スコア表示準備中', {
-        scoreRating: scoreRating,
-        sakuraPercentage: sakuraPercentage
+  function clearRoot(root) {
+    while (root.firstChild) {
+      root.removeChild(root.firstChild);
+    }
+  }
+
+  function appendHeader(root, statusText) {
+    const header = document.createElement("div");
+    header.className = "sc-header";
+
+    const badge = document.createElement("span");
+    badge.className = "sc-badge";
+    badge.textContent = "サクラチェッカー";
+
+    const status = document.createElement("span");
+    status.className = "sc-status";
+    status.textContent = statusText;
+
+    header.appendChild(badge);
+    header.appendChild(status);
+    root.appendChild(header);
+  }
+
+  function appendActions(root, options) {
+    const actions = document.createElement("div");
+    actions.className = "sc-actions";
+
+    if (options.onRetry) {
+      const retryButton = document.createElement("button");
+      retryButton.type = "button";
+      retryButton.className = "sc-button";
+      retryButton.textContent = "再試行";
+      retryButton.addEventListener("click", options.onRetry);
+      actions.appendChild(retryButton);
+    }
+
+    if (options.sourceUrl) {
+      const openLink = document.createElement("a");
+      openLink.className = "sc-link";
+      openLink.href = options.sourceUrl;
+      openLink.target = "_blank";
+      openLink.rel = "noopener noreferrer";
+      openLink.textContent = "サクラチェッカーを開く";
+      actions.appendChild(openLink);
+    }
+
+    root.appendChild(actions);
+  }
+
+  function renderLoading() {
+    const root = ensureRoot();
+    root.dataset.state = "loading";
+    clearRoot(root);
+    appendHeader(root, "取得中");
+
+    const message = document.createElement("div");
+    message.className = "sc-message";
+    message.textContent =
+      "サクラチェッカーからスコア画像を取得しています。";
+    root.appendChild(message);
+  }
+
+  function renderSuccess(payload, onRetry) {
+    const root = ensureRoot();
+    root.dataset.state = "success";
+    clearRoot(root);
+    appendHeader(root, payload.cached ? "キャッシュ表示" : "取得完了");
+
+    const score = document.createElement("div");
+    score.className = "sc-score";
+
+    for (const image of payload.score.images) {
+      const img = document.createElement("img");
+      img.src = image.src;
+      img.alt = image.alt || "サクラチェッカーのスコア";
+      score.appendChild(img);
+    }
+
+    const suffix = document.createElement("span");
+    suffix.className = "sc-suffix";
+    suffix.textContent = payload.score.suffix;
+    score.appendChild(suffix);
+    root.appendChild(score);
+
+    const message = document.createElement("div");
+    message.className = "sc-message";
+    message.textContent =
+      "サクラチェッカー上で表示されているスコア画像をそのまま表示しています。";
+    root.appendChild(message);
+
+    const meta = document.createElement("div");
+    meta.className = "sc-meta";
+    meta.textContent = `取得日時: ${new Date(payload.fetchedAt).toLocaleString("ja-JP")}`;
+    root.appendChild(meta);
+
+    appendActions(root, { onRetry, sourceUrl: payload.sourceUrl });
+  }
+
+  function renderError(payload, onRetry) {
+    const root = ensureRoot();
+    root.dataset.state = "error";
+    clearRoot(root);
+    appendHeader(root, "取得失敗");
+
+    const message = document.createElement("div");
+    message.className = "sc-message";
+    message.textContent =
+      payload && payload.message
+        ? payload.message
+        : "サクラチェッカーのスコア画像を取得できませんでした。";
+    root.appendChild(message);
+
+    appendActions(root, {
+      onRetry,
+      sourceUrl: payload && payload.sourceUrl ? payload.sourceUrl : null,
     });
-    
-    // 既存の結果要素を削除
-    const existingResult = document.querySelector('#sakura-checker-result');
-    if (existingResult) {
-        existingResult.remove();
-    }
-    
-    // 結果表示要素を作成
-    const resultElement = createDualScoreElement(scoreRating, sakuraPercentage, asin);
-    
-    // 挿入位置を特定
-    const insertionPoint = findInsertionPoint();
-    
-    if (insertionPoint) {
-        insertionPoint.insertAdjacentElement('afterend', resultElement);
-    } else {
-        // フォールバック: body要素の最初に追加
-        document.body.insertAdjacentElement('afterbegin', resultElement);
-    }
-}
+  }
 
-// 両方のスコア表示要素を作成する関数
-function createDualScoreElement(scoreRating, sakuraPercentage, asin) {
-    const resultDiv = document.createElement('div');
-    resultDiv.id = 'sakura-checker-result';
-    
-    // サクラ度に応じた色とメッセージを決定（パーセンテージが優先）
-    let color, backgroundColor, message, riskLevel;
-    
-    if (sakuraPercentage !== null) {
-        const scoreInfo = getSakuraScoreInfo(sakuraPercentage);
-        color = scoreInfo.color;
-        backgroundColor = scoreInfo.backgroundColor;
-        message = scoreInfo.message;
-        riskLevel = scoreInfo.riskLevel;
-    } else {
-        // パーセンテージがない場合はニュートラルな色
-        color = '#6c757d';
-        backgroundColor = '#f8f9fa';
-        message = 'スコア情報を取得しました。';
-        riskLevel = '情報';
+  function remove() {
+    const root = document.getElementById(ROOT_ID);
+    if (root) {
+      root.remove();
     }
-    
-    // 表示するスコア情報を構築
-    let scoresDisplay = '';
-    
-    if (sakuraPercentage !== null) {
-        // sakuraPercentageが画像オブジェクトかどうかをチェック
-        if (typeof sakuraPercentage === 'object' && sakuraPercentage.type === 'image') {
-            scoresDisplay += `
-                <span style="
-                    font-size: 16px;
-                    font-weight: bold;
-                    color: ${color};
-                    margin-right: 10px;
-                    display: flex;
-                    align-items: center;
-                    gap: 5px;
-                ">
-                    サクラ度: 
-                    <img src="${sakuraPercentage.imageData}" style="display: inline; vertical-align: middle; max-height: 20px;">
-                    ${sakuraPercentage.suffix}
-                </span>
-            `;
-        } else if (typeof sakuraPercentage === 'object' && sakuraPercentage.type === 'html') {
-            scoresDisplay += `
-                <span style="
-                    font-size: 16px;
-                    font-weight: bold;
-                    color: ${color};
-                    margin-right: 10px;
-                    display: flex;
-                    align-items: center;
-                    gap: 5px;
-                ">
-                    サクラ度: ${sakuraPercentage.htmlContent}
-                </span>
-            `;
-        } else {
-            scoresDisplay += `
-                <span style="
-                    font-size: 16px;
-                    font-weight: bold;
-                    color: ${color};
-                    margin-right: 10px;
-                ">
-                    サクラ度: ${sakuraPercentage}%
-                </span>
-            `;
-        }
-    }
-    
-    if (scoreRating !== null) {
-        console.log('UI Display: scoreRating詳細:', {
-            value: scoreRating,
-            type: typeof scoreRating,
-            isObject: typeof scoreRating === 'object',
-            hasTypeProperty: scoreRating && scoreRating.type,
-            typeProperty: scoreRating && scoreRating.type
-        });
-        
-        // scoreRatingが画像オブジェクトかどうかをチェック
-        if (typeof scoreRating === 'object' && scoreRating.type === 'image') {
-            console.log('UI Display: base64画像として表示:', scoreRating);
-            scoresDisplay += `
-                <span style="
-                    font-size: 14px;
-                    color: #495057;
-                    background-color: #e9ecef;
-                    padding: 2px 6px;
-                    border-radius: 3px;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 3px;
-                    vertical-align: middle;
-                ">
-                    スコア:&nbsp;
-                    <img src="${scoreRating.imageData}" style="display: inline-block; vertical-align: middle; height: 16px; width: auto; border: 1px solid #ccc;">
-                    ${scoreRating.suffix}
-                </span>
-            `;
-        } else if (typeof scoreRating === 'object' && scoreRating.type === 'html') {
-            console.log('UI Display: HTML画像として表示:', scoreRating);
-            scoresDisplay += `
-                <span style="
-                    font-size: 14px;
-                    color: #495057;
-                    background-color: #e9ecef;
-                    padding: 2px 6px;
-                    border-radius: 3px;
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 3px;
-                    vertical-align: middle;
-                ">
-                    スコア: ${scoreRating.htmlContent}
-                </span>
-            `;
-        } else {
-            scoresDisplay += `
-                <span style="
-                    font-size: 14px;
-                    color: #495057;
-                    background-color: #e9ecef;
-                    padding: 2px 6px;
-                    border-radius: 3px;
-                ">
-                    スコア: ${scoreRating}
-                </span>
-            `;
-        }
-    }
-    
-    if (!scoresDisplay) {
-        scoresDisplay = `
-            <span style="
-                font-size: 14px;
-                color: #6c757d;
-            ">
-                スコア情報なし
-            </span>
-        `;
-    }
-    
-    resultDiv.innerHTML = `
-        <div style="
-            background-color: ${backgroundColor};
-            border: 2px solid ${color};
-            border-radius: 8px;
-            padding: 12px;
-            margin: 10px 0;
-            font-family: 'Arial', sans-serif;
-            font-size: 14px;
-            line-height: 1.4;
-            color: #333;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            position: relative;
-            z-index: 1000;
-        ">
-            <div style="
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                margin-bottom: 8px;
-            ">
-                <span style="
-                    background-color: ${color};
-                    color: white;
-                    padding: 4px 8px;
-                    border-radius: 4px;
-                    font-weight: bold;
-                    font-size: 12px;
-                ">
-                    🌸 サクラチェック
-                </span>
-                ${scoresDisplay}
-                ${sakuraPercentage !== null ? `
-                <span style="
-                    font-size: 12px;
-                    color: #666;
-                ">
-                    ${riskLevel}
-                </span>
-                ` : ''}
-            </div>
-            <div style="
-                font-size: 13px;
-                color: #555;
-                margin-bottom: 8px;
-            ">
-                ${message}
-            </div>
-            <div style="
-                font-size: 11px;
-                color: #999;
-                text-align: right;
-            ">
-                Powered by sakura-checker.jp
-            </div>
-        </div>
-    `;
-    
-    return resultDiv;
-}
+  }
 
-// サクラ度に応じた表示情報を取得する関数
-function getSakuraScoreInfo(sakuraScore) {
-    if (sakuraScore >= 80) {
-        return {
-            color: '#dc3545',
-            backgroundColor: '#fff5f5',
-            message: 'サクラの可能性が非常に高いです。レビューに注意してください。',
-            riskLevel: '危険'
-        };
-    } else if (sakuraScore >= 60) {
-        return {
-            color: '#fd7e14',
-            backgroundColor: '#fff8f0',
-            message: 'サクラの可能性があります。レビューを慎重に確認してください。',
-            riskLevel: '注意'
-        };
-    } else if (sakuraScore >= 40) {
-        return {
-            color: '#ffc107',
-            backgroundColor: '#fffef0',
-            message: 'レビューに多少の疑問があります。',
-            riskLevel: '軽微'
-        };
-    } else {
-        return {
-            color: '#28a745',
-            backgroundColor: '#f8fff8',
-            message: 'レビューは比較的信頼できると思われます。',
-            riskLevel: '安全'
-        };
-    }
-}
-
-// 結果を挿入する位置を特定する関数
-function findInsertionPoint() {
-    // 商品タイトルの後に挿入を試みる
-    const productTitle = document.querySelector('#productTitle');
-    if (productTitle) {
-        return productTitle.parentElement;
-    }
-    
-    // 価格情報の前に挿入を試みる
-    const priceElement = document.querySelector('#priceblock_dealprice, #priceblock_ourprice, .a-price');
-    if (priceElement) {
-        return priceElement.parentElement;
-    }
-    
-    // 商品情報エリアを探す
-    const productInfo = document.querySelector('#feature-bullets, #productDescription');
-    if (productInfo) {
-        return productInfo.parentElement;
-    }
-    
-    // フォールバック: レビューセクションの前
-    const reviewSection = document.querySelector('#reviews, #reviewsMedley');
-    if (reviewSection) {
-        return reviewSection.parentElement;
-    }
-    
-    return null;
-}
-
-// エクスポート（グローバルスコープで利用可能にする）
-window.UiDisplay = {
-    displayLoadingResult,
-    displayErrorResult,
-    displayDualScoreResult,
-    createLoadingElement,
-    createErrorElement,
-    createDualScoreElement,
-    getSakuraScoreInfo,
-    findInsertionPoint
-};
+  window.UiDisplay = {
+    ensureRoot,
+    remove,
+    renderError,
+    renderLoading,
+    renderSuccess,
+  };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,12 @@
   "manifest_version": 3,
   "name": "Amazon Display Sakura Checker",
   "version": "1.0.0",
-  "description": "Amazon商品ページでサクラチェックを行うChrome拡張機能",
+  "description": "Amazon.co.jpの商品詳細ページにサクラチェッカーのスコア画像を表示します。",
   "permissions": [
-    "activeTab",
     "storage"
   ],
   "host_permissions": [
     "https://www.amazon.co.jp/*",
-    "https://www.amazon.com/*",
     "https://sakura-checker.jp/*"
   ],
   "background": {
@@ -18,12 +16,11 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.amazon.co.jp/*",
-        "https://www.amazon.com/*"
+        "https://www.amazon.co.jp/*"
       ],
       "js": [
         "content/asin-extractor.js",
-        "content/ui-display.js", 
+        "content/ui-display.js",
         "content/sakura-checker.js",
         "content.js"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "amazon-display-sakurachecker",
   "version": "1.0.0",
-  "description": "Amazon商品ページでサクラチェックを行うChrome拡張機能",
+  "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
+  "scripts": {
+    "test": "node --test tests/parser.test.js tests/api-client.test.js tests/integration.test.js"
+  },
   "keywords": [
     "chrome-extension",
     "amazon",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -1,0 +1,107 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const apiClient = require("../background/api-client.js");
+const fixtures = require("./fixtures.js");
+
+function installChromeStorageStub() {
+  const store = new Map();
+
+  global.chrome = {
+    storage: {
+      local: {
+        get(keys, callback) {
+          const result = {};
+          for (const key of keys) {
+            if (store.has(key)) {
+              result[key] = store.get(key);
+            }
+          }
+          callback(result);
+        },
+        set(entries, callback) {
+          for (const [key, value] of Object.entries(entries)) {
+            store.set(key, value);
+          }
+          callback();
+        },
+      },
+    },
+  };
+
+  return () => {
+    delete global.chrome;
+  };
+}
+
+test("buildSourceUrl creates the Sakura Checker search URL", () => {
+  assert.equal(
+    apiClient.buildSourceUrl("B08N5WRWNW"),
+    "https://sakura-checker.jp/search/B08N5WRWNW/"
+  );
+});
+
+test("checkSakuraScore caches successful responses", async () => {
+  const cleanup = installChromeStorageStub();
+  let fetchCalls = 0;
+
+  try {
+    const fetchImpl = async () => {
+      fetchCalls += 1;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => fixtures.sampleHtml,
+      };
+    };
+
+    const first = await apiClient.checkSakuraScore({
+      asin: "B08N5WRWNW",
+      forceRefresh: false,
+      fetchImpl,
+    });
+    const second = await apiClient.checkSakuraScore({
+      asin: "B08N5WRWNW",
+      forceRefresh: false,
+      fetchImpl,
+    });
+
+    assert.equal(first.ok, true);
+    assert.equal(first.cached, false);
+    assert.equal(second.ok, true);
+    assert.equal(second.cached, true);
+    assert.equal(fetchCalls, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("checkSakuraScore returns blocked for rate limited responses", async () => {
+  const result = await apiClient.checkSakuraScore({
+    asin: "B08N5WRWNW",
+    forceRefresh: true,
+    fetchImpl: async () => ({
+      ok: false,
+      status: 429,
+      text: async () => "",
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "blocked");
+});
+
+test("checkSakuraScore returns not_found for missing products", async () => {
+  const result = await apiClient.checkSakuraScore({
+    asin: "B08N5WRWNW",
+    forceRefresh: true,
+    fetchImpl: async () => ({
+      ok: false,
+      status: 404,
+      text: async () => "",
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "not_found");
+});

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,0 +1,66 @@
+const scrambledScoreValue = [
+  "1WRVVBQUFEbE4wL2xOMC9sTjAvbE4wL2xOMC9sTjAvbE4wL2xOMCtBazVsZkFBQUFD",
+  "SFJTVGxNQVFMK0F6NDhnRU9YaW9NRUFBQUE1U1VSQlZEakxZeGdGRkFNMll5REFLc1BZ",
+  "QVFTak1zTkNSZ2tLVkVBeU1JNHFTS1lERzJnYTdESURINkZGF0YTppbWFnZS9wbmc7YmFz",
+  "ZTY0LGlWQk9SdzBLR2dvQUFBQU5TVWhFVWdBQUFESUFBQUJEQkFNQUFBQXNiMHZtQUFBQUcx",
+  "QktqTW9OSmhsMFFDQmlHTmdBQWVNZW9NNEZ1aHZJQUFBQUFTVVZPUks1Q1lJST0=",
+].join("");
+
+const sampleImageTag = [
+  '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"',
+  'alt="score"',
+  `KTzIOIAzVx2Qrw5_="${scrambledScoreValue}"`,
+  `onload="var _s=this['getAttribute']('KTzIOIAzVx2Qrw5_');var _n=98;var _m=62;"`,
+  ">",
+].join(" ");
+
+const otherImageTag = sampleImageTag.replace('alt="score"', 'alt="other"');
+
+const otherReviewWrap = `
+  <div class="item-review-wrap">
+    <div class="item-image">
+      <a href="https://www.amazon.co.jp/dp/B000000000/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+    </div>
+    <div class="item-info sample-other">
+      <div class="item-review-box">
+        <div class="item-review-after">
+          <p class="item-rating"><span>${otherImageTag}</span>/5</p>
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+
+const targetReviewWrap = `
+  <div class="item-review-wrap">
+    <div class="item-image">
+      <a href="https://www.amazon.co.jp/dp/B08N5WRWNW/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+    </div>
+    <div class="item-info sample-target">
+      <div class="item-review-box">
+        <div class="item-review-after">
+          <p class="item-rating"><span>${sampleImageTag}</span>/5</p>
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+
+const sampleHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      ${otherReviewWrap}
+      ${targetReviewWrap}
+      <p class="item-btn"><a href="https://www.amazon.co.jp/dp/B08N5WRWNW/?tag=sakurachecker-22"></a></p>
+    </body>
+  </html>
+`;
+
+module.exports = {
+  otherReviewWrap,
+  sampleHtml,
+  sampleImageTag,
+  scrambledScoreValue,
+  targetReviewWrap,
+};

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const apiClient = require("../background/api-client.js");
+
+const knownAsins = ["B08N5WRWNW", "B0921THFXZ", "B0CP4V4RPL"];
+
+function liveFetch(url, options) {
+  return fetch(url, {
+    ...options,
+    headers: {
+      ...(options && options.headers ? options.headers : {}),
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+      "Accept-Language": "ja,en-US;q=0.9,en;q=0.8",
+    },
+  });
+}
+
+for (const asin of knownAsins) {
+  test(`live fetch returns a visual score for ${asin}`, async () => {
+    const result = await apiClient.checkSakuraScore({
+      asin,
+      forceRefresh: true,
+      fetchImpl: liveFetch,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.score.kind, "visual-image");
+    assert.ok(result.score.images.length >= 1);
+
+    for (const image of result.score.images) {
+      assert.match(image.src, /^data:image\/png;base64,/);
+    }
+  });
+}

--- a/tests/manual-browser-check.md
+++ b/tests/manual-browser-check.md
@@ -1,0 +1,10 @@
+# Manual Browser Check
+
+1. Open `chrome://extensions`.
+2. Enable developer mode and load this repository as an unpacked extension.
+3. Open an Amazon.co.jp product page with a known ASIN such as `B08N5WRWNW`.
+4. Confirm a `サクラチェッカー` panel appears near the title area.
+5. Confirm the panel first shows `取得中` and then shows a decoded score image plus `/5`.
+6. Click `再試行` and confirm the panel refreshes without leaving the page.
+7. Click `サクラチェッカーを開く` and confirm it opens `https://sakura-checker.jp/search/<ASIN>/`.
+8. Open a non-product page on Amazon.co.jp and confirm the panel is removed.

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,51 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const parser = require("../background/score-parser.js");
+const fixtures = require("./fixtures.js");
+
+test("decodeObfuscatedImageTag restores a data URL", () => {
+  const decoded = parser.decodeObfuscatedImageTag(fixtures.sampleImageTag);
+
+  assert.ok(decoded);
+  assert.match(decoded.src, /^data:image\/png;base64,/);
+  assert.equal(decoded.alt, "score");
+});
+
+test("parseVisualScore selects the block matching the requested ASIN", () => {
+  const result = parser.parseVisualScore(fixtures.sampleHtml, "B08N5WRWNW");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "visual-image");
+  assert.equal(result.score.images.length, 1);
+  assert.equal(result.score.suffix, "/5");
+  assert.equal(result.score.images[0].alt, "score");
+});
+
+test("parseVisualScore returns not_found when no matching ASIN exists", () => {
+  const result = parser.parseVisualScore(fixtures.sampleHtml, "B111111111");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "not_found");
+});
+
+test("parseVisualScore returns parse_error when rating markup is missing", () => {
+  const brokenTarget = fixtures.targetReviewWrap.replace(
+    '<p class="item-rating"><span>',
+    '<p class="missing-rating"><span>'
+  );
+  const brokenHtml = `
+    <!DOCTYPE html>
+    <html lang="ja">
+      <body>
+        ${fixtures.otherReviewWrap}
+        ${brokenTarget}
+        <p class="item-btn"><a href="https://www.amazon.co.jp/dp/B08N5WRWNW/?tag=sakurachecker-22"></a></p>
+      </body>
+    </html>
+  `;
+  const result = parser.parseVisualScore(brokenHtml, "B08N5WRWNW");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "parse_error");
+});


### PR DESCRIPTION
## Summary
- rebuild the extension around visual score image extraction instead of numeric parsing
- limit support to Amazon.co.jp product detail pages and add a simpler loading/success/error UI with retry
- add parser, cache, fixture, and live integration tests plus a manual browser check checklist

## Validation
- npm test

## Remaining
- browser-side manual acceptance check from `tests/manual-browser-check.md`
