### PR TITLE
WIP: Fix injected Sakura Checker score extraction

### DIFF
--- a/background/score-parser.js
+++ b/background/score-parser.js
@@ -8,6 +8,7 @@
   const REVIEW_WRAP_MARKER = '<div class="item-review-wrap">';
   const ITEM_BUTTON_MARKER = '<p class="item-btn">';
   const ITEM_RATING_MARKER = '<p class="item-rating">';
+  const ITEM_REVIEW_LEVEL_MARKER = '<div class="item-review-level">';
 
   function getReviewWrapRanges(html) {
     const starts = [];
@@ -56,6 +57,13 @@
     }
 
     return block.slice(start, end + 4);
+  }
+
+  function extractRatingMarkups(markup) {
+    return Array.from(
+      markup.matchAll(/<p class="item-rating">[\s\S]*?<\/p>/g),
+      (match) => match[0]
+    );
   }
 
   function extractImageTags(markup) {
@@ -204,28 +212,148 @@
     };
   }
 
+  function decodeUrlEncodedBase64Payload(encodedPayload) {
+    try {
+      return decodeURIComponent(decodeBase64ToText(encodedPayload));
+    } catch {
+      return null;
+    }
+  }
+
+  function extractInlineScriptBodies(html) {
+    return Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
+  }
+
+  function extractDecodedScriptBodies(scriptBody) {
+    const decodedBodies = [];
+    const matches = scriptBody.matchAll(/window\[[^\]]+\]\('([^']+)'\)/g);
+
+    for (const match of matches) {
+      try {
+        decodedBodies.push(decodeBase64ToText(match[1]));
+      } catch {
+        continue;
+      }
+    }
+
+    return decodedBodies;
+  }
+
+  function extractScriptStringAssignments(scriptBody) {
+    const assignments = new Map();
+
+    for (const match of scriptBody.matchAll(/var\s+([A-Za-z0-9_$]+)\s*=\s*'([^']*)';/g)) {
+      assignments.set(match[1], match[2]);
+    }
+
+    return assignments;
+  }
+
+  function extractInjectedHtmlSnippetsFromScript(scriptBody) {
+    const assignments = extractScriptStringAssignments(scriptBody);
+    const snippets = new Set();
+
+    for (const match of scriptBody.matchAll(
+      /(?:before|html)\(decodeURIComponent\(atob\(([A-Za-z0-9_$]+)\)\)\)/g
+    )) {
+      const encodedPayload = assignments.get(match[1]);
+      if (!encodedPayload) {
+        continue;
+      }
+
+      const decodedSnippet = decodeUrlEncodedBase64Payload(encodedPayload);
+      if (decodedSnippet) {
+        snippets.add(decodedSnippet);
+      }
+    }
+
+    for (const encodedPayload of assignments.values()) {
+      const decodedSnippet = decodeUrlEncodedBase64Payload(encodedPayload);
+      if (
+        decodedSnippet &&
+        decodedSnippet.includes("<") &&
+        decodedSnippet.includes(">") &&
+        (
+          decodedSnippet.includes(ITEM_RATING_MARKER) ||
+          decodedSnippet.includes(ITEM_REVIEW_LEVEL_MARKER) ||
+          decodedSnippet.includes("sakura-alert")
+        )
+      ) {
+        snippets.add(decodedSnippet);
+      }
+    }
+
+    return Array.from(snippets);
+  }
+
+  function extractInjectedHtmlSnippets(html) {
+    const snippets = [];
+
+    for (const scriptBody of extractInlineScriptBodies(html)) {
+      snippets.push(...extractInjectedHtmlSnippetsFromScript(scriptBody));
+
+      for (const decodedScriptBody of extractDecodedScriptBodies(scriptBody)) {
+        snippets.push(...extractInjectedHtmlSnippetsFromScript(decodedScriptBody));
+      }
+    }
+
+    return snippets;
+  }
+
+  function findPrimaryInjectedSnippet(html) {
+    const snippets = extractInjectedHtmlSnippets(html).filter((snippet) =>
+      snippet.includes(ITEM_RATING_MARKER)
+    );
+
+    return (
+      snippets.find(
+        (snippet) =>
+          snippet.includes(ITEM_REVIEW_LEVEL_MARKER) && snippet.includes("item-review-after")
+      ) || null
+    );
+  }
+
+  function findRatingMarkupBeforeMarker(markup, marker) {
+    const markerIndex = markup.indexOf(marker);
+    const searchableMarkup = markerIndex === -1 ? markup : markup.slice(0, markerIndex);
+    const ratings = extractRatingMarkups(searchableMarkup);
+
+    return ratings.length ? ratings[ratings.length - 1] : null;
+  }
+
+  function decodeRatingImages(ratingMarkup) {
+    return extractImageTags(ratingMarkup).map(decodeObfuscatedImageTag).filter(Boolean);
+  }
+
   function parseVisualScore(html, asin) {
-    const productBlock = findPrimaryProductBlock(html, asin);
-    if (!productBlock) {
-      return {
-        ok: false,
-        code: "not_found",
-        message: `Could not find a Sakura Checker block for ASIN ${asin}.`,
-      };
+    let ratingMarkup = null;
+
+    const injectedSnippet = findPrimaryInjectedSnippet(html);
+    if (injectedSnippet) {
+      ratingMarkup = findRatingMarkupBeforeMarker(injectedSnippet, ITEM_REVIEW_LEVEL_MARKER);
     }
 
-    const ratingMarkup = findRatingMarkup(productBlock);
     if (!ratingMarkup) {
-      return {
-        ok: false,
-        code: "parse_error",
-        message: "Could not locate the item-rating markup.",
-      };
+      const productBlock = findPrimaryProductBlock(html, asin);
+      if (!productBlock) {
+        return {
+          ok: false,
+          code: "not_found",
+          message: `Could not find a Sakura Checker block for ASIN ${asin}.`,
+        };
+      }
+
+      ratingMarkup = findRatingMarkup(productBlock);
+      if (!ratingMarkup) {
+        return {
+          ok: false,
+          code: "parse_error",
+          message: "Could not locate the item-rating markup.",
+        };
+      }
     }
 
-    const images = extractImageTags(ratingMarkup)
-      .map(decodeObfuscatedImageTag)
-      .filter(Boolean);
+    const images = decodeRatingImages(ratingMarkup);
 
     if (!images.length) {
       return {
@@ -246,10 +374,19 @@
   }
 
   return {
+    decodeRatingImages,
     decodeObfuscatedImageTag,
+    decodeUrlEncodedBase64Payload,
+    extractDecodedScriptBodies,
+    extractInjectedHtmlSnippets,
     extractImageTags,
+    extractInlineScriptBodies,
+    extractRatingMarkups,
+    extractScriptStringAssignments,
     findPrimaryProductBlock,
+    findPrimaryInjectedSnippet,
     findRatingMarkup,
+    findRatingMarkupBeforeMarker,
     parseAttributes,
     parseVisualScore,
     restoreObfuscatedValue,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
-    "test": "node --test tests/parser.test.js tests/api-client.test.js tests/integration.test.js"
+    "test": "node --test tests/parser.test.js tests/api-client.test.js tests/integration.test.js tests/browser-compare.test.js"
   },
   "keywords": [
     "chrome-extension",

--- a/tests/browser-compare.test.js
+++ b/tests/browser-compare.test.js
@@ -1,0 +1,369 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const parser = require("../background/score-parser.js");
+
+const CHROME_PATHS = [
+  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+  "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+];
+const WAIT_TIMEOUT_MS = 30000;
+
+function getChromePath() {
+  return CHROME_PATHS.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+async function fetchHtml(url) {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+      "Accept-Language": "ja,en-US;q=0.9,en;q=0.8",
+    },
+  });
+
+  assert.equal(response.ok, true);
+  return response.text();
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForJsonVersion(port) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (response.ok) {
+        return response.json();
+      }
+    } catch {
+      // Wait for Chrome to start listening.
+    }
+
+    await delay(200);
+  }
+
+  throw new Error("Timed out waiting for Chrome DevTools endpoint.");
+}
+
+async function waitForPageWebSocketUrl(port) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      if (response.ok) {
+        const targets = await response.json();
+        const pageTarget = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+        if (pageTarget) {
+          return pageTarget.webSocketDebuggerUrl;
+        }
+      }
+    } catch {
+      // Wait for the initial page target to become available.
+    }
+
+    await delay(200);
+  }
+
+  throw new Error("Timed out waiting for a Chrome page target.");
+}
+
+class CdpClient {
+  constructor(webSocketUrl) {
+    this.nextId = 1;
+    this.pending = new Map();
+    this.socket = new WebSocket(webSocketUrl);
+    this.opened = new Promise((resolve, reject) => {
+      this.socket.addEventListener("open", () => resolve());
+      this.socket.addEventListener("error", (event) => reject(event.error || new Error("CDP socket error")));
+    });
+    this.socket.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!Object.prototype.hasOwnProperty.call(message, "id")) {
+        return;
+      }
+
+      const pending = this.pending.get(message.id);
+      if (!pending) {
+        return;
+      }
+
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || "CDP command failed."));
+        return;
+      }
+
+      pending.resolve(message.result);
+    });
+  }
+
+  async send(method, params = {}) {
+    await this.opened;
+    const id = this.nextId;
+    this.nextId += 1;
+
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  async close() {
+    if (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING) {
+      this.socket.close();
+    }
+
+    await delay(100);
+  }
+}
+
+async function launchChrome(chromePath) {
+  const port = 9000 + Math.floor(Math.random() * 1000);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "sakura-checker-test-"));
+  const chromeProcess = spawn(
+    chromePath,
+    [
+      "--headless=new",
+      "--disable-gpu",
+      "--no-first-run",
+      "--no-default-browser-check",
+      `--user-data-dir=${userDataDir}`,
+      `--remote-debugging-port=${port}`,
+      "about:blank",
+    ],
+    {
+      stdio: "ignore",
+      windowsHide: true,
+    }
+  );
+
+  try {
+    await waitForJsonVersion(port);
+    const pageWebSocketUrl = await waitForPageWebSocketUrl(port);
+    return {
+      chromeProcess,
+      cdpClient: new CdpClient(pageWebSocketUrl),
+      userDataDir,
+    };
+  } catch (error) {
+    chromeProcess.kill("SIGKILL");
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function closeChrome(session) {
+  await session.cdpClient.close();
+  if (!session.chromeProcess.killed) {
+    session.chromeProcess.kill("SIGKILL");
+  }
+
+  await new Promise((resolve) => {
+    if (session.chromeProcess.exitCode !== null) {
+      resolve();
+      return;
+    }
+
+    session.chromeProcess.once("exit", () => resolve());
+    setTimeout(resolve, 2000);
+  });
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      fs.rmSync(session.userDataDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (error && error.code !== "EPERM") {
+        throw error;
+      }
+      await delay(200);
+    }
+  }
+
+  fs.rmSync(session.userDataDir, { recursive: true, force: true });
+}
+
+async function evaluateValue(cdpClient, expression) {
+  const result = await cdpClient.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.text || "Browser evaluation failed.");
+  }
+
+  return result.result.value;
+}
+
+async function waitForRenderedPrimaryScoreImages(cdpClient) {
+  const expression = `(() => {
+    const reviewLevel =
+      document.querySelector(".item-review-after .item-review-level") ||
+      document.querySelector(".item-review-level");
+    if (!reviewLevel) {
+      return null;
+    }
+
+    const reviewCard = reviewLevel.closest(".item-review-after") || reviewLevel.parentElement;
+    const rating =
+      reviewCard && reviewCard.querySelector
+        ? reviewCard.querySelector("p.item-rating")
+        : null;
+    if (!rating) {
+      return null;
+    }
+
+    const images = Array.from(rating.querySelectorAll("img")).map((image) => ({
+      src: image.getAttribute("src") || image.src,
+      alt: image.getAttribute("alt") || "",
+    }));
+
+    if (images.length < 2 || images.some((image) => !image.src || !image.src.startsWith("data:image/"))) {
+      return null;
+    }
+
+    return images;
+  })()`;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+    const images = await evaluateValue(cdpClient, expression);
+    if (images) {
+      return images;
+    }
+
+    await delay(250);
+  }
+
+  throw new Error("Timed out waiting for the rendered top score images.");
+}
+
+async function compareRenderedScorePixels(cdpClient, parsedImages) {
+  const expression = `(() => {
+    const parsedSources = ${JSON.stringify(parsedImages.map((image) => image.src))};
+
+    async function renderSourcesToDataUrl(sources) {
+      const loadedImages = await Promise.all(
+        sources.map((source) => new Promise((resolve, reject) => {
+          const image = new Image();
+          image.onload = () => resolve(image);
+          image.onerror = () => reject(new Error("Failed to load score image."));
+          image.src = source;
+        }))
+      );
+
+      const width = loadedImages.reduce((total, image) => total + image.naturalWidth, 0);
+      const height = loadedImages.reduce((maxHeight, image) => Math.max(maxHeight, image.naturalHeight), 0);
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+
+      const context = canvas.getContext("2d");
+      let offsetX = 0;
+      for (const image of loadedImages) {
+        context.drawImage(image, offsetX, 0);
+        offsetX += image.naturalWidth;
+      }
+
+      return canvas.toDataURL("image/png");
+    }
+
+    return (async () => {
+      const reviewLevel =
+        document.querySelector(".item-review-after .item-review-level") ||
+        document.querySelector(".item-review-level");
+      if (!reviewLevel) {
+        return null;
+      }
+
+      const reviewCard = reviewLevel.closest(".item-review-after") || reviewLevel.parentElement;
+      const rating =
+        reviewCard && reviewCard.querySelector
+          ? reviewCard.querySelector("p.item-rating")
+          : null;
+      if (!rating) {
+        return null;
+      }
+
+      const displayedSources = Array.from(rating.querySelectorAll("img")).map(
+        (image) => image.getAttribute("src") || image.src
+      );
+      if (displayedSources.length < 2) {
+        return null;
+      }
+
+      return {
+        displayedCount: displayedSources.length,
+        parsedCount: parsedSources.length,
+        displayedComposite: await renderSourcesToDataUrl(displayedSources),
+        parsedComposite: await renderSourcesToDataUrl(parsedSources),
+      };
+    })();
+  })()`;
+
+  return evaluateValue(cdpClient, expression);
+}
+
+async function captureScreenshotOnFailure(cdpClient, asin) {
+  try {
+    const result = await cdpClient.send("Page.captureScreenshot", { format: "png" });
+    const screenshotPath = path.join(os.tmpdir(), `sakura-browser-compare-${asin}.png`);
+    fs.writeFileSync(screenshotPath, Buffer.from(result.data, "base64"));
+    return screenshotPath;
+  } catch {
+    return null;
+  }
+}
+
+const chromePath = getChromePath();
+
+test("browser-rendered top score visually matches the parsed raw HTML score for B095JGJCC7", {
+  skip: !chromePath || typeof WebSocket !== "function",
+  timeout: 45000,
+}, async () => {
+  const asin = "B095JGJCC7";
+  const url = `https://sakura-checker.jp/search/${asin}/`;
+  const rawHtml = await fetchHtml(url);
+  const parsed = parser.parseVisualScore(rawHtml, asin);
+
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.score.images.length >= 2);
+
+  const session = await launchChrome(chromePath);
+
+  try {
+    await session.cdpClient.send("Page.enable");
+    await session.cdpClient.send("Runtime.enable");
+    await session.cdpClient.send("Page.navigate", { url });
+
+    await waitForRenderedPrimaryScoreImages(session.cdpClient);
+    const comparison = await compareRenderedScorePixels(session.cdpClient, parsed.score.images);
+
+    assert.ok(comparison, "Could not compare the rendered score images.");
+    assert.equal(comparison.parsedCount, parsed.score.images.length);
+    assert.equal(comparison.displayedCount, parsed.score.images.length);
+    assert.equal(comparison.parsedComposite, comparison.displayedComposite);
+  } catch (error) {
+    const screenshotPath = await captureScreenshotOnFailure(session.cdpClient, asin);
+    if (screenshotPath) {
+      error.message = `${error.message} Screenshot: ${screenshotPath}`;
+    }
+    throw error;
+  } finally {
+    await closeChrome(session);
+  }
+});

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -57,7 +57,50 @@ const sampleHtml = `
   </html>
 `;
 
+const injectedScoreMarkup = `
+  <div class="item-review-after">
+    <p class="item-logo"><img src="/images/logo_s.png" alt="サクラチェッカー"></p>
+    <p class="item-rating"><span>${sampleImageTag}${otherImageTag}</span>/5</p>
+  </div>
+  <div class="item-review-level">
+    <p class="item-rv-score">Amazonと同等のスコア</p>
+  </div>
+`;
+
+const injectedPayload = Buffer.from(encodeURIComponent(injectedScoreMarkup), "utf8").toString(
+  "base64"
+);
+
+const injectedDecodedScript = `
+  var injectedPayload = '${injectedPayload}';
+  $(function () {
+    $("#dynamic-score-anchor").before(decodeURIComponent(atob(injectedPayload)));
+    $("#dynamic-score-anchor").remove();
+  });
+`;
+
+const injectedScript = `
+  var _0x = "eval";
+  window[_0x]('${Buffer.from(injectedDecodedScript, "utf8").toString("base64")}');
+`;
+
+const htmlWithInjectedScore = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      ${targetReviewWrap}
+      <div class="item-review-box"><span id="dynamic-score-anchor"></span></div>
+      <script>${injectedScript}</script>
+    </body>
+  </html>
+`;
+
 module.exports = {
+  htmlWithInjectedScore,
+  injectedDecodedScript,
+  injectedPayload,
+  injectedScoreMarkup,
+  injectedScript,
   otherReviewWrap,
   sampleHtml,
   sampleImageTag,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert/strict");
 
 const apiClient = require("../background/api-client.js");
 
-const knownAsins = ["B08N5WRWNW", "B0921THFXZ", "B0CP4V4RPL"];
+const knownAsins = ["B08N5WRWNW", "B0921THFXZ", "B0CP4V4RPL", "B095JGJCC7"];
 
 function liveFetch(url, options) {
   return fetch(url, {

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -22,6 +22,25 @@ test("parseVisualScore selects the block matching the requested ASIN", () => {
   assert.equal(result.score.images[0].alt, "score");
 });
 
+test("extractInjectedHtmlSnippets decodes nested inline script payloads", () => {
+  const snippets = parser.extractInjectedHtmlSnippets(fixtures.htmlWithInjectedScore);
+
+  assert.equal(snippets.length, 1);
+  assert.match(snippets[0], /item-review-level/);
+  assert.match(snippets[0], /Amazonと同等のスコア/);
+});
+
+test("parseVisualScore prefers the injected main score markup", () => {
+  const result = parser.parseVisualScore(fixtures.htmlWithInjectedScore, "B08N5WRWNW");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.images.length, 2);
+  assert.deepEqual(
+    result.score.images.map((image) => image.alt),
+    ["score", "other"]
+  );
+});
+
 test("parseVisualScore returns not_found when no matching ASIN exists", () => {
   const result = parser.parseVisualScore(fixtures.sampleHtml, "B111111111");
 


### PR DESCRIPTION
## Summary
- fix Sakura Checker top score extraction so injected score markup is preferred over the stale inline plus-only rating
- add parser fixtures and live integration coverage for ASIN `B095JGJCC7`
- add a browser comparison test that renders Sakura Checker in headless Chrome/Edge and verifies the parsed score visually matches the displayed score

## Testing
- npm test
