### PR TITLE
Add Sakura Checker verdict extraction and display

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -17,6 +17,40 @@
     return `https://sakura-checker.jp/search/${asin}/`;
   }
 
+  function resolveSakuraUrl(value) {
+    if (!value) {
+      return value;
+    }
+
+    if (/^https?:\/\//i.test(value)) {
+      return value;
+    }
+
+    if (value.startsWith("//")) {
+      return `https:${value}`;
+    }
+
+    try {
+      return new URL(value, "https://sakura-checker.jp").toString();
+    } catch {
+      return value;
+    }
+  }
+
+  function normalizeVerdict(verdict) {
+    if (!verdict || !verdict.image) {
+      return verdict || null;
+    }
+
+    return {
+      ...verdict,
+      image: {
+        ...verdict.image,
+        src: resolveSakuraUrl(verdict.image.src),
+      },
+    };
+  }
+
   function createFailure(code, message, sourceUrl) {
     return { ok: false, code, message, sourceUrl };
   }
@@ -151,6 +185,7 @@
       fetchedAt: new Date().toISOString(),
       sourceUrl,
       score: parsed.score,
+      verdict: normalizeVerdict(parsed.verdict),
     };
 
     await writeCache(asin, payload);

--- a/background/score-parser.js
+++ b/background/score-parser.js
@@ -9,6 +9,7 @@
   const ITEM_BUTTON_MARKER = '<p class="item-btn">';
   const ITEM_RATING_MARKER = '<p class="item-rating">';
   const ITEM_REVIEW_LEVEL_MARKER = '<div class="item-review-level">';
+  const ITEM_REVIEW_SCORE_MARKER = '<p class="item-rv-score">';
 
   function getReviewWrapRanges(html) {
     const starts = [];
@@ -59,6 +60,20 @@
     return block.slice(start, end + 4);
   }
 
+  function findReviewLevelMarkup(block) {
+    const start = block.indexOf(ITEM_REVIEW_LEVEL_MARKER);
+    if (start === -1) {
+      return null;
+    }
+
+    const end = block.indexOf("</div>", start);
+    if (end === -1) {
+      return null;
+    }
+
+    return block.slice(start, end + 6);
+  }
+
   function extractRatingMarkups(markup) {
     return Array.from(
       markup.matchAll(/<p class="item-rating">[\s\S]*?<\/p>/g),
@@ -107,11 +122,12 @@
 
   function parseAttributes(tag) {
     const attributes = {};
-    const attributePattern = /([^\s=/>]+)="([^"]*)"/g;
+    const attributePattern =
+      /([^\s=<>\/]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
     let match = null;
 
     while ((match = attributePattern.exec(tag)) !== null) {
-      attributes[match[1]] = match[2];
+      attributes[match[1]] = match[2] ?? match[3] ?? match[4] ?? "";
     }
 
     return attributes;
@@ -325,12 +341,81 @@
     return extractImageTags(ratingMarkup).map(decodeObfuscatedImageTag).filter(Boolean);
   }
 
+  function decodeHtmlEntities(text) {
+    return text
+      .replace(/&nbsp;/g, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+  }
+
+  function normalizeVerdictLine(text) {
+    return decodeHtmlEntities(text.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim());
+  }
+
+  function decodeVerdictImage(levelMarkup) {
+    const imageTag = extractImageTags(levelMarkup)[0];
+    if (!imageTag) {
+      return null;
+    }
+
+    const attributes = parseAttributes(imageTag);
+    if (!attributes.src) {
+      return null;
+    }
+
+    return {
+      src: attributes.src,
+      alt: attributes.alt || "",
+    };
+  }
+
+  function decodeVerdictLines(levelMarkup) {
+    const start = levelMarkup.indexOf(ITEM_REVIEW_SCORE_MARKER);
+    if (start === -1) {
+      return [];
+    }
+
+    const end = levelMarkup.indexOf("</p>", start);
+    if (end === -1) {
+      return [];
+    }
+
+    const scoreMarkup = levelMarkup.slice(
+      start + ITEM_REVIEW_SCORE_MARKER.length,
+      end
+    );
+    return scoreMarkup
+      .split(/<br\s*\/?>/i)
+      .map(normalizeVerdictLine)
+      .filter(Boolean);
+  }
+
+  function decodeVerdict(levelMarkup) {
+    const image = decodeVerdictImage(levelMarkup);
+    const lines = decodeVerdictLines(levelMarkup);
+
+    if (!image || !lines.length) {
+      return null;
+    }
+
+    return {
+      kind: "visual-verdict",
+      image,
+      lines,
+    };
+  }
+
   function parseVisualScore(html, asin) {
     let ratingMarkup = null;
+    let reviewLevelMarkup = null;
 
     const injectedSnippet = findPrimaryInjectedSnippet(html);
     if (injectedSnippet) {
       ratingMarkup = findRatingMarkupBeforeMarker(injectedSnippet, ITEM_REVIEW_LEVEL_MARKER);
+      reviewLevelMarkup = findReviewLevelMarkup(injectedSnippet);
     }
 
     if (!ratingMarkup) {
@@ -344,6 +429,7 @@
       }
 
       ratingMarkup = findRatingMarkup(productBlock);
+      reviewLevelMarkup = findReviewLevelMarkup(productBlock);
       if (!ratingMarkup) {
         return {
           ok: false,
@@ -354,6 +440,7 @@
     }
 
     const images = decodeRatingImages(ratingMarkup);
+    const verdict = reviewLevelMarkup ? decodeVerdict(reviewLevelMarkup) : null;
 
     if (!images.length) {
       return {
@@ -370,10 +457,14 @@
         images,
         suffix: "/5",
       },
+      verdict,
     };
   }
 
   return {
+    decodeVerdict,
+    decodeVerdictImage,
+    decodeVerdictLines,
     decodeRatingImages,
     decodeObfuscatedImageTag,
     decodeUrlEncodedBase64Payload,
@@ -387,6 +478,7 @@
     findPrimaryInjectedSnippet,
     findRatingMarkup,
     findRatingMarkupBeforeMarker,
+    findReviewLevelMarkup,
     parseAttributes,
     parseVisualScore,
     restoreObfuscatedValue,

--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -51,6 +51,13 @@
         align-items: center;
         gap: 4px;
         min-height: 28px;
+      }
+
+      #${ROOT_ID} .sc-primary {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px 20px;
         margin-bottom: 10px;
       }
 
@@ -58,6 +65,29 @@
         max-height: 28px;
         width: auto;
         display: block;
+      }
+
+      #${ROOT_ID} .sc-verdict {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-height: 28px;
+      }
+
+      #${ROOT_ID} .sc-verdict img {
+        max-height: 32px;
+        width: auto;
+        display: block;
+      }
+
+      #${ROOT_ID} .sc-verdict-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-size: 14px;
+        font-weight: 700;
+        line-height: 1.35;
+        color: #0f1111;
       }
 
       #${ROOT_ID} .sc-suffix {
@@ -214,6 +244,9 @@
     clearRoot(root);
     appendHeader(root, payload.cached ? "キャッシュ表示" : "取得完了");
 
+    const primary = document.createElement("div");
+    primary.className = "sc-primary";
+
     const score = document.createElement("div");
     score.className = "sc-score";
 
@@ -228,7 +261,30 @@
     suffix.className = "sc-suffix";
     suffix.textContent = payload.score.suffix;
     score.appendChild(suffix);
-    root.appendChild(score);
+    primary.appendChild(score);
+
+    if (payload.verdict && payload.verdict.image && payload.verdict.lines?.length) {
+      const verdict = document.createElement("div");
+      verdict.className = "sc-verdict";
+
+      const icon = document.createElement("img");
+      icon.src = payload.verdict.image.src;
+      icon.alt = payload.verdict.image.alt || "サクラチェッカーの判定";
+      verdict.appendChild(icon);
+
+      const text = document.createElement("div");
+      text.className = "sc-verdict-text";
+      for (const line of payload.verdict.lines) {
+        const lineElement = document.createElement("span");
+        lineElement.textContent = line;
+        text.appendChild(lineElement);
+      }
+
+      verdict.appendChild(text);
+      primary.appendChild(verdict);
+    }
+
+    root.appendChild(primary);
 
     const message = document.createElement("div");
     message.className = "sc-message";

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -68,8 +68,17 @@ test("checkSakuraScore caches successful responses", async () => {
 
     assert.equal(first.ok, true);
     assert.equal(first.cached, false);
+    assert.deepEqual(first.verdict, {
+      kind: "visual-verdict",
+      image: {
+        src: "https://sakura-checker.jp/images/rv_level03.png",
+        alt: "判定",
+      },
+      lines: ["Amazonより", "かなり低いスコア"],
+    });
     assert.equal(second.ok, true);
     assert.equal(second.cached, true);
+    assert.deepEqual(second.verdict, first.verdict);
     assert.equal(fetchCalls, 1);
   } finally {
     cleanup();

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -15,6 +15,8 @@ const sampleImageTag = [
 ].join(" ");
 
 const otherImageTag = sampleImageTag.replace('alt="score"', 'alt="other"');
+const verdictImageTag = '<img src=/images/rv_level03.png alt="判定">';
+const fallbackVerdictImageTag = '<img src=/images/rv_level00.png alt="判定">';
 
 const otherReviewWrap = `
   <div class="item-review-wrap">
@@ -25,6 +27,10 @@ const otherReviewWrap = `
       <div class="item-review-box">
         <div class="item-review-after">
           <p class="item-rating"><span>${otherImageTag}</span>/5</p>
+          <div class="item-review-level">
+            <p class="item-rv-lv item-rv-lv00">${fallbackVerdictImageTag}</p>
+            <p class="item-rv-score">評価件数不足で<br>分析不可</p>
+          </div>
         </div>
       </div>
     </div>
@@ -40,6 +46,10 @@ const targetReviewWrap = `
       <div class="item-review-box">
         <div class="item-review-after">
           <p class="item-rating"><span>${sampleImageTag}</span>/5</p>
+          <div class="item-review-level">
+            <p class="item-rv-lv item-rv-lv03">${verdictImageTag}</p>
+            <p class="item-rv-score">Amazonより<br>かなり低いスコア</p>
+          </div>
         </div>
       </div>
     </div>
@@ -63,7 +73,8 @@ const injectedScoreMarkup = `
     <p class="item-rating"><span>${sampleImageTag}${otherImageTag}</span>/5</p>
   </div>
   <div class="item-review-level">
-    <p class="item-rv-score">Amazonと同等のスコア</p>
+    <p class="item-rv-lv item-rv-lv02">${verdictImageTag}</p>
+    <p class="item-rv-score">Amazonと<br>同等のスコア</p>
   </div>
 `;
 
@@ -106,4 +117,5 @@ module.exports = {
   sampleImageTag,
   scrambledScoreValue,
   targetReviewWrap,
+  verdictImageTag,
 };

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -32,5 +32,13 @@ for (const asin of knownAsins) {
     for (const image of result.score.images) {
       assert.match(image.src, /^data:image\/png;base64,/);
     }
+
+    if (result.verdict) {
+      assert.equal(result.verdict.kind, "visual-verdict");
+      assert.match(result.verdict.image.src, /^https:\/\/sakura-checker\.jp\//);
+      assert.ok(result.verdict.lines.length >= 1);
+    } else {
+      assert.equal(result.verdict, null);
+    }
   });
 }

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -20,6 +20,14 @@ test("parseVisualScore selects the block matching the requested ASIN", () => {
   assert.equal(result.score.images.length, 1);
   assert.equal(result.score.suffix, "/5");
   assert.equal(result.score.images[0].alt, "score");
+  assert.deepEqual(result.verdict, {
+    kind: "visual-verdict",
+    image: {
+      src: "/images/rv_level03.png",
+      alt: "判定",
+    },
+    lines: ["Amazonより", "かなり低いスコア"],
+  });
 });
 
 test("extractInjectedHtmlSnippets decodes nested inline script payloads", () => {
@@ -27,7 +35,7 @@ test("extractInjectedHtmlSnippets decodes nested inline script payloads", () => 
 
   assert.equal(snippets.length, 1);
   assert.match(snippets[0], /item-review-level/);
-  assert.match(snippets[0], /Amazonと同等のスコア/);
+  assert.match(snippets[0], /Amazonと<br>同等のスコア/);
 });
 
 test("parseVisualScore prefers the injected main score markup", () => {
@@ -39,6 +47,14 @@ test("parseVisualScore prefers the injected main score markup", () => {
     result.score.images.map((image) => image.alt),
     ["score", "other"]
   );
+  assert.deepEqual(result.verdict, {
+    kind: "visual-verdict",
+    image: {
+      src: "/images/rv_level03.png",
+      alt: "判定",
+    },
+    lines: ["Amazonと", "同等のスコア"],
+  });
 });
 
 test("parseVisualScore returns not_found when no matching ASIN exists", () => {
@@ -67,4 +83,21 @@ test("parseVisualScore returns parse_error when rating markup is missing", () =>
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "parse_error");
+});
+
+test("parseVisualScore keeps score when the verdict block is missing", () => {
+  const targetWithoutVerdict = fixtures.targetReviewWrap.replace(
+    /<div class="item-review-level">[\s\S]*?<\/div>\s*/,
+    ""
+  );
+  const htmlWithoutVerdict = fixtures.sampleHtml.replace(
+    fixtures.targetReviewWrap,
+    targetWithoutVerdict
+  );
+
+  const result = parser.parseVisualScore(htmlWithoutVerdict, "B08N5WRWNW");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.images.length, 1);
+  assert.equal(result.verdict, null);
 });


### PR DESCRIPTION
## Summary
- extract Sakura Checker verdict data from the item-review-level block alongside the existing score images
- normalize verdict image URLs in the API payload/cache and render verdict image + multiline text in the updated main-branch layout
- add parser, API, integration, and browser-compare coverage for verdict handling and the no-verdict fallback

## Testing
- node --test tests/parser.test.js tests/api-client.test.js tests/integration.test.js tests/browser-compare.test.js