### PR TITLE
Fix Sakura Checker result alignment

### DIFF
--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -54,7 +54,7 @@
         display: flex;
         align-items: center;
         gap: 8px 12px;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         min-height: 28px;
       }
 
@@ -87,13 +87,6 @@
         max-height: 32px;
         width: auto;
         display: block;
-      }
-
-      #${ROOT_ID} .sc-verdict-text {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        line-height: 1.35;
       }
 
       #${ROOT_ID} .sc-status-value {
@@ -204,7 +197,7 @@
   }
 
   function createVerdictNode(verdict) {
-    if (!verdict || !verdict.image || !verdict.lines || !verdict.lines.length) {
+    if (!verdict || !verdict.image) {
       return null;
     }
 
@@ -216,16 +209,6 @@
     icon.alt = verdict.image.alt || "サクラチェッカーの判定";
     verdictNode.appendChild(icon);
 
-    const text = document.createElement("div");
-    text.className = "sc-verdict-text";
-
-    for (const line of verdict.lines) {
-      const lineNode = document.createElement("span");
-      lineNode.textContent = line;
-      text.appendChild(lineNode);
-    }
-
-    verdictNode.appendChild(text);
     return verdictNode;
   }
 


### PR DESCRIPTION
## Summary
- keep the score block and verdict icon on a single horizontal line
- remove verdict text and show only the verdict image to prevent width-dependent layout shifts

## Validation
- node --check content/ui-display.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CSS: flex-wrap設定の変更** / スコア値とアイコンを同一行に配置するため、sc-score-valueのflex-wrapをwrapからnowrapに変更
- **判定テキスト構造の削除** / レイアウトの幅依存シフトを防ぐため、DOMから.sc-verdict-text全体を削除
- **JavaScript判定ロジックの簡略化** / 判定テキスト行の描画を無効化するため、createVerdictNodeの検証をverdict.linesの確認から削除し、判定画像のみを表示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->