### PR TITLE
Fix Chrome Web Store deploy diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,13 @@ jobs:
             exit 0
           fi
 
-          if git diff --name-only HEAD~1 HEAD | grep -q '^package\.json$' && \
-            git diff --unified=0 HEAD~1 HEAD -- package.json | grep -qE '^[+-][[:space:]]*"version"[[:space:]]*:'; then
+          previous_version="$(git show HEAD~1:package.json | python3 -c 'import json, sys; print(json.load(sys.stdin)[\"version\"])')"
+          current_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path(\"package.json\").read_text(encoding=\"utf-8\"))[\"version\"])')"
+
+          echo "Previous package.json version: ${previous_version}"
+          echo "Current package.json version: ${current_version}"
+
+          if [ "$previous_version" != "$current_version" ]; then
             echo "version-changed=true" >> "$GITHUB_OUTPUT"
             echo "Version changed, proceeding with deployment"
           else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
           if git diff --name-only HEAD~1 HEAD | grep -q '^package\.json$' && \
-            git diff HEAD~1 HEAD -- package.json | grep -q '"version"'; then
+            git diff --unified=0 HEAD~1 HEAD -- package.json | grep -qE '^[+-][[:space:]]*"version"[[:space:]]*:'; then
             echo "version-changed=true" >> "$GITHUB_OUTPUT"
             echo "Version changed, proceeding with deployment"
           else
@@ -58,11 +58,12 @@ jobs:
 
       - name: Upload to Chrome Web Store
         if: steps.version-check.outputs.version-changed == 'true'
-        uses: mnao305/chrome-extension-upload@v5.0.0
-        with:
-          file-path: extension.zip
-          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
-          client-id: ${{ secrets.CHROME_CLIENT_ID }}
-          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          publish: true
+        env:
+          CHROME_EXTENSION_ZIP_PATH: extension.zip
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISH: "true"
+        run: node scripts/upload-chrome-web-store.js

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,6 +11,7 @@ This repository uses GitHub Actions to submit the Chrome extension to the Chrome
 1. Open the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole).
 2. Create the extension listing and complete the initial manual upload.
 3. Copy the extension ID from the dashboard URL.
+4. Copy the publisher ID used by the Chrome Web Store API.
 
 ### 2. Create Google API credentials
 
@@ -34,9 +35,12 @@ The refresh token is the value used by GitHub Actions.
 Add these repository secrets in GitHub: `Settings -> Secrets and variables -> Actions`.
 
 - `CHROME_EXTENSION_ID`
+- `CHROME_PUBLISHER_ID`
 - `CHROME_CLIENT_ID`
 - `CHROME_CLIENT_SECRET`
 - `CHROME_REFRESH_TOKEN`
+
+The workflow now calls the Chrome Web Store API directly so upload failures include the API response body and a `fetchStatus` snapshot in the GitHub Actions log.
 
 ## Release flow
 

--- a/scripts/upload-chrome-web-store.js
+++ b/scripts/upload-chrome-web-store.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const API_ROOT = "https://chromewebstore.googleapis.com";
+const POLL_INTERVAL_MS = 5000;
+const MAX_STATUS_POLLS = 12;
+
+function readRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function buildItemPath(publisherId, extensionId) {
+  return `publishers/${encodeURIComponent(publisherId)}/items/${encodeURIComponent(extensionId)}`;
+}
+
+function buildApiUrl(itemPath, action, { upload = false } = {}) {
+  const baseUrl = upload ? `${API_ROOT}/upload/v2/${itemPath}` : `${API_ROOT}/v2/${itemPath}`;
+  const url = new URL(action ? `${baseUrl}:${action}` : baseUrl);
+  url.searchParams.set("$.xgafv", "2");
+  if (upload) {
+    url.searchParams.set("uploadType", "media");
+  }
+  return url;
+}
+
+async function parseResponse(response) {
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!text) {
+    return { contentType, body: null };
+  }
+
+  if (contentType.includes("application/json")) {
+    return { contentType, body: JSON.parse(text) };
+  }
+
+  try {
+    return { contentType, body: JSON.parse(text) };
+  } catch {
+    return { contentType, body: text };
+  }
+}
+
+function formatBody(body) {
+  if (body === null || body === undefined) {
+    return "(empty response)";
+  }
+
+  if (typeof body === "string") {
+    return body;
+  }
+
+  return JSON.stringify(body, null, 2);
+}
+
+async function requestJson(label, url, options) {
+  const response = await fetch(url, options);
+  const parsed = await parseResponse(response);
+
+  if (!response.ok) {
+    const error = new Error(`${label} failed: HTTP ${response.status} ${response.statusText}`);
+    error.details = {
+      label,
+      status: response.status,
+      statusText: response.statusText,
+      contentType: parsed.contentType,
+      body: parsed.body,
+    };
+    throw error;
+  }
+
+  return parsed.body;
+}
+
+async function getAccessToken(clientId, clientSecret, refreshToken) {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await requestJson("OAuth token request", TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response || typeof response.access_token !== "string") {
+    throw new Error("OAuth token response did not include an access_token");
+  }
+
+  return response.access_token;
+}
+
+async function fetchStatus(itemPath, accessToken) {
+  const url = buildApiUrl(itemPath, "fetchStatus");
+
+  return requestJson("Fetch status", url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
+async function uploadPackage(itemPath, accessToken, zipPath) {
+  const archive = fs.readFileSync(zipPath);
+  const url = buildApiUrl(itemPath, "upload", { upload: true });
+
+  return requestJson("Upload package", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "content-type": "application/zip",
+      "content-length": String(archive.length),
+    },
+    body: archive,
+  });
+}
+
+async function publishItem(itemPath, accessToken) {
+  const url = buildApiUrl(itemPath, "publish");
+
+  return requestJson("Publish item", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      publishType: "DEFAULT_PUBLISH",
+      skipReview: false,
+    }),
+  });
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForUploadResult(itemPath, accessToken) {
+  for (let attempt = 1; attempt <= MAX_STATUS_POLLS; attempt += 1) {
+    const status = await fetchStatus(itemPath, accessToken);
+    console.log(`Fetch status attempt ${attempt}/${MAX_STATUS_POLLS}:`);
+    console.log(formatBody(status));
+
+    const uploadState = status && status.lastAsyncUploadState;
+    if (uploadState === "SUCCEEDED" || uploadState === "FAILED" || uploadState === "NOT_FOUND") {
+      return status;
+    }
+
+    if (attempt < MAX_STATUS_POLLS) {
+      await sleep(POLL_INTERVAL_MS);
+    }
+  }
+
+  throw new Error(
+    `Upload status did not settle after ${MAX_STATUS_POLLS} attempts (${(MAX_STATUS_POLLS * POLL_INTERVAL_MS) / 1000}s)`
+  );
+}
+
+async function logStatusSnapshot(itemPath, accessToken, heading) {
+  try {
+    const status = await fetchStatus(itemPath, accessToken);
+    console.error(`${heading}:`);
+    console.error(formatBody(status));
+  } catch (statusError) {
+    console.error(`${heading} failed: ${statusError.message}`);
+    if (statusError.details) {
+      console.error(formatBody(statusError.details));
+    }
+  }
+}
+
+async function main() {
+  const extensionId = readRequiredEnv("CHROME_EXTENSION_ID");
+  const publisherId = readRequiredEnv("CHROME_PUBLISHER_ID");
+  const clientId = readRequiredEnv("CHROME_CLIENT_ID");
+  const clientSecret = readRequiredEnv("CHROME_CLIENT_SECRET");
+  const refreshToken = readRequiredEnv("CHROME_REFRESH_TOKEN");
+  const zipPath = path.resolve(process.env.CHROME_EXTENSION_ZIP_PATH || "extension.zip");
+  const shouldPublish = (process.env.CHROME_PUBLISH || "true").toLowerCase() !== "false";
+
+  if (!fs.existsSync(zipPath)) {
+    throw new Error(`Extension archive not found: ${zipPath}`);
+  }
+
+  const itemPath = buildItemPath(publisherId, extensionId);
+  let accessToken;
+
+  console.log(`Preparing Chrome Web Store upload for item ${extensionId}`);
+  console.log(`Archive: ${zipPath}`);
+
+  try {
+    accessToken = await getAccessToken(clientId, clientSecret, refreshToken);
+    console.log("OAuth access token acquired.");
+
+    const uploadResponse = await uploadPackage(itemPath, accessToken, zipPath);
+    console.log("Upload response:");
+    console.log(formatBody(uploadResponse));
+
+    let uploadState = uploadResponse && uploadResponse.uploadState;
+    if (uploadState === "IN_PROGRESS") {
+      const status = await waitForUploadResult(itemPath, accessToken);
+      uploadState = status && status.lastAsyncUploadState;
+    }
+
+    if (uploadState && uploadState !== "SUCCEEDED") {
+      throw new Error(`Upload did not succeed. Final upload state: ${uploadState}`);
+    }
+
+    await logStatusSnapshot(itemPath, accessToken, "Status after upload");
+
+    if (!shouldPublish) {
+      return;
+    }
+
+    const publishResponse = await publishItem(itemPath, accessToken);
+    console.log("Publish response:");
+    console.log(formatBody(publishResponse));
+    await logStatusSnapshot(itemPath, accessToken, "Status after publish");
+  } catch (error) {
+    console.error(error.message);
+    if (error.details) {
+      console.error("API error details:");
+      console.error(formatBody(error.details));
+    }
+
+    if (accessToken) {
+      await logStatusSnapshot(itemPath, accessToken, "Status snapshot after failure");
+    }
+
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/upload-chrome-web-store.js
+++ b/scripts/upload-chrome-web-store.js
@@ -61,6 +61,10 @@ function formatBody(body) {
   return JSON.stringify(body, null, 2);
 }
 
+function isUploadPending(uploadState) {
+  return uploadState === "IN_PROGRESS" || uploadState === "UPLOAD_IN_PROGRESS";
+}
+
 async function requestJson(label, url, options) {
   const response = await fetch(url, options);
   const parsed = await parseResponse(response);
@@ -210,7 +214,7 @@ async function main() {
     console.log(formatBody(uploadResponse));
 
     let uploadState = uploadResponse && uploadResponse.uploadState;
-    if (uploadState === "IN_PROGRESS") {
+    if (isUploadPending(uploadState)) {
       const status = await waitForUploadResult(itemPath, accessToken);
       uploadState = status && status.lastAsyncUploadState;
     }


### PR DESCRIPTION
## Summary
- fix the deploy workflow so it only triggers when the package version line actually changes
- replace the opaque Chrome Web Store upload action with a script that logs API error bodies and fetchStatus snapshots
- handle async upload states including `UPLOAD_IN_PROGRESS`
- document the additional `CHROME_PUBLISHER_ID` secret

## Validation
- node --check scripts/upload-chrome-web-store.js
- npm test
- npm ci
- npm run zip
- confirmed the old version check would falsely trigger on `aac0e74..7c9933c` while the new check does not

## Notes
- CI now requires the `CHROME_PUBLISHER_ID` GitHub Actions secret
- live Chrome Web Store API calls were not exercised locally because the required secrets are not available in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- デプロイワークフローのバージョン検出を改善 / `git diff --unified=0`で"version"フィールドの変更のみを検出し、誤ったデプロイトリガーを防止するため
- Chrome Web Storeアップロード方式をGitHub Actionからカスタムスクリプトに切り替え / APIエラーレスポンスとfetchStatusスナップショットをログに記録し、デバッグ効率を向上させるため
- GitHub Actionsシークレット`CHROME_PUBLISHER_ID`を新規追加 / Chrome Web Store APIの認証に必要であるため
- 非同期アップロード状態（`UPLOAD_IN_PROGRESS`）のポーリング処理を実装 / アップロード完了まで適切に状態遷移を監視するため
- DEPLOYMENT.mdのセットアップ手順とシークレット一覧を更新 / 新しい要件と動作変更を反映させるため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->