### PR TITLE
Fix deploy version check quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,8 @@ jobs:
             exit 0
           fi
 
-          previous_version="$(git show HEAD~1:package.json | python3 -c 'import json, sys; print(json.load(sys.stdin)[\"version\"])')"
-          current_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path(\"package.json\").read_text(encoding=\"utf-8\"))[\"version\"])')"
+          previous_version="$(git show HEAD~1:package.json | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')"
+          current_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("package.json").read_text(encoding="utf-8"))["version"])')"
 
           echo "Previous package.json version: ${previous_version}"
           echo "Current package.json version: ${current_version}"


### PR DESCRIPTION
## Summary
- fix the Python one-liners in the deploy workflow so the parsed `package.json` version check runs correctly under GitHub Actions bash
- keep the top-level `package.json` version comparison introduced in the previous deploy diagnostics work

## Validation
- verified the resulting diff against `origin/main` is limited to the quoting fix in `.github/workflows/deploy.yml`
- GitHub Actions-style execution could not be reproduced locally because this Windows environment does not provide the `python3` command name used by ubuntu runners

## Notes
- this is a follow-up to merged PR #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- GitHub Actions の bash で Python ワンライナーの引用符を修正 / シェル変数展開時に内側のダブルクォートが正しく解釈されるようにするため
- `previous_version` コマンドの JSON キーアクセス `[\"version\"]` をエスケープなし `["version"]` に修正 / bash から Python へ正しい引数を渡すため  
- `current_version` コマンドのファイルパス `\"package.json\"` と JSON キー `[\"version\"]` をエスケープなしに修正 / 同様に bash の字句解析で正しく処理するため
- PR #14 で導入したトップレベル package.json バージョン比較機能を維持しながら、実行環境での動作を修正

<!-- end of auto-generated comment: release notes by coderabbit.ai -->