### PR TITLE
Reorganize README for users and developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,38 @@
 
 `Amazon Display Sakura Checker` は、Amazon.co.jp の商品ページ上に Sakura Checker の評価画像を表示する Chrome 拡張です。
 
-Chrome Web Store での公開を前提に、機能だけでなく、権限・通信・保存データの扱いをこの README に明記します。
+Chrome Web Store での公開を前提に、利用者向けには権限・通信・保存データの扱いを、開発者向けにはセットアップ・テスト・配布手順をまとめています。
 
-## 関連ドキュメント
+## 利用者向け
 
-- [Chrome Web Store デプロイ手順](./DEPLOYMENT.md)
-- [プライバシーポリシー](./PRIVACY_POLICY.md)
-- [ライセンス](./LICENSE)
-
-## 単一目的
+### できること
 
 この拡張の目的は 1 つです。
 
-- Amazon.co.jp の商品ページで、対象商品の ASIN を取得する
+- Amazon.co.jp の商品ページから ASIN を取得する
 - Sakura Checker の該当ページを参照する
 - 取得できた評価画像と判定文を Amazon 商品ページ内に表示する
 
 それ以外の用途には使いません。
 
-## 利用者向けの透明性
+### 使い方
 
-### 何を読み取るか
+Amazon.co.jp の商品ページを開くと、商品タイトル付近に Sakura Checker の表示ブロックを追加します。
+
+- 読み込み中表示
+- Sakura Checker の評価画像
+- 判定画像と判定文
+- Sakura Checker の元ページへのリンク
+
+ページ外への自動投稿、レビュー投稿、クリック代行は行いません。
+
+### 動作対象
+
+- 対応サイト: `https://www.amazon.co.jp/*`
+- 対応ページ: 商品詳細ページ
+- 非対応: Amazon.co.jp 以外のドメイン、Sakura Checker に対象商品が存在しない商品
+
+### 読み取る情報
 
 この拡張は Amazon.co.jp の商品ページで次の情報だけを参照します。
 
@@ -31,24 +42,21 @@ Chrome Web Store での公開を前提に、機能だけでなく、権限・通
 
 レビュー本文、購入履歴、氏名、住所、支払い情報、Amazon アカウント情報を読む実装はありません。
 
-### どこに通信するか
+### 外部通信
 
-外部通信先は次の 1 つです。
+外部通信先は次の 1 つだけです。
 
 - [Sakura Checker](https://sakura-checker.jp/)
 
 通信内容は、商品 ASIN に対応する Sakura Checker の検索ページへの `GET` リクエストです。
 
-実際の参照先:
-
 - `https://sakura-checker.jp/search/<ASIN>/`
 
-現在の実装では、Amazon 側のページ本文やレビュー本文は Sakura Checker に送信しません。ASIN を使って該当ページを取得します。
+Amazon 側のページ本文やレビュー本文を Sakura Checker に送信することはありません。ASIN を使って該当ページを取得します。
 
-### 何を保存するか
+### 保存する情報
 
-`chrome.storage.local` に、取得結果のキャッシュを保存します。
-取得時には、Sakura Checker の描画後 DOM を読むために `active: false` の一時タブを短時間だけ開いてすぐ閉じることがあります。
+`chrome.storage.local` に取得結果のキャッシュを保存します。
 
 - キー: `score:<ASIN>`
 - 保存内容: 取得時刻、Sakura Checker の参照 URL、評価画像情報、判定画像情報
@@ -56,7 +64,9 @@ Chrome Web Store での公開を前提に、機能だけでなく、権限・通
 
 これは同じ商品を再表示したときの不要な再取得を減らすためのローカルキャッシュです。
 
-### 何を保存しないか
+取得時には、Sakura Checker の描画後 DOM を読むために `active: false` の一時タブを短時間だけ開いて、読み取り後すぐ閉じることがあります。
+
+### 保存しない情報
 
 この拡張は次の情報を保存しません。
 
@@ -67,122 +77,101 @@ Chrome Web Store での公開を前提に、機能だけでなく、権限・通
 - 広告識別子
 - 解析イベントやトラッキングデータ
 
-### 収集・販売・共有について
+### 収集・販売・共有
 
 - 開発者サーバーへの独自送信は行いません
 - 収集したデータの販売は行いません
 - 広告用途の共有は行いません
 - ユーザー識別のための分析 SDK は含みません
 
-## Chrome 拡張の権限
+### 拡張が要求する権限
 
 `manifest.json` で要求している権限は次のとおりです。
 
-### `storage`
+- `storage`: Sakura Checker の取得結果を 12 時間キャッシュするため
+- `tabs`: Sakura Checker の描画後 DOM を読むために、`active: false` の一時タブを短時間作成して閉じるため
+- `scripting`: 一時タブ上の Sakura Checker ページへスクリプトを注入し、描画後の DOM を読み取るため
+- `https://www.amazon.co.jp/*`: Amazon.co.jp の商品ページで拡張を動かし、ASIN を読み取って表示 UI を挿入するため
+- `https://sakura-checker.jp/*`: Sakura Checker の商品ページを取得し、評価画像と判定情報を表示するため
 
-用途:
-
-- Sakura Checker の取得結果を 12 時間キャッシュするため
-
-### `tabs`
-
-用途:
-
-- Sakura Checker の描画後 DOM を読むために、`active: false` の一時タブを短時間作成するため
-- 描画後のスコア取得が終わったら一時タブをすぐ閉じるため
-
-### `scripting`
-
-用途:
-
-- 一時タブ上の Sakura Checker ページへスクリプトを注入して実行するため
-- 描画後の DOM を読み取り、ブラウザ上で実際に表示されたスコアカードを取得するため
-
-### `https://www.amazon.co.jp/*`
-
-用途:
-
-- Amazon.co.jp の商品ページでコンテンツスクリプトを動かすため
-- 商品ページ URL と ASIN を読み取るため
-- 商品ページ内に評価表示 UI を挿入するため
-
-### `https://sakura-checker.jp/*`
-
-用途:
-
-- Sakura Checker の商品ページを取得するため
-- 評価画像と判定情報を表示するため
-
-## 画面上で行うこと
-
-Amazon.co.jp の商品ページで、商品タイトル周辺の領域に表示ブロックを追加します。
-
-- 読み込み中表示
-- Sakura Checker の評価画像
-- 判定画像と判定文
-- Sakura Checker の元ページへのリンク
-
-ページ外への自動投稿、レビュー投稿、クリック代行は行いません。
-
-## 制限事項
+### 制限事項
 
 - Sakura Checker 側に対象商品がない場合は結果を表示できません
 - Sakura Checker 側の HTML 構造が変わると解析に失敗する可能性があります
 - `403`、`429`、タイムアウト時はエラー表示になります
 - Amazon.co.jp 以外では動作しません
 
-## 開発
+### 関連ドキュメント
 
-### ローカルで読み込む
+- [プライバシーポリシー](./PRIVACY_POLICY.md)
+- [ライセンス](./LICENSE)
 
-1. Chrome で `chrome://extensions/` を開く
-2. デベロッパーモードを有効にする
-3. `パッケージ化されていない拡張機能を読み込む` からこのディレクトリを選ぶ
-
-### テスト
-
-```bash
-npm test
-```
-
-実行対象:
-
-- HTML 解析ロジックの単体テスト
-- API クライアントのテスト
-- 結合テスト
-- ブラウザ比較テスト
-
-### Chrome Web Store 提出用 zip を作る
-
-```bash
-npm install
-npm run zip
-```
-
-`npm run zip` は `package.json` の version を `manifest.json` に同期したうえで、拡張の実行に必要なファイルだけを含む `extension.zip` をリポジトリ直下へ生成します。Chrome Web Store への手動アップロードにはこの zip を使います。
-
-## 公開時に説明欄へ転記できる要約
+### ストア説明欄に転記できる要約
 
 この拡張は Amazon.co.jp の商品ページで ASIN を読み取り、Sakura Checker の公開ページを参照して評価画像を表示します。外部通信先は Sakura Checker のみです。個人情報、Amazon アカウント情報、入力内容、閲覧履歴一覧は収集しません。取得結果は再取得を減らすためにブラウザ内へ 12 時間キャッシュします。
 
-## ライセンス
+## 開発者向け
 
-MIT
+### リポジトリ概要
 
-## Test commands
+このリポジトリは、Amazon 商品ページ上に Sakura Checker の結果を埋め込む Chrome 拡張を管理します。
 
-Use the following commands depending on the level of validation you need:
+- `content/`: ASIN 取得、表示 UI、Sakura Checker 連携のコンテンツスクリプト
+- `background.js`: 一時タブ生成、描画後 DOM 読み取り、キャッシュ制御を行う service worker
+- `tests/`: パーサー、API クライアント、コンテンツフロー、外部連携のテスト
+- `scripts/`: zip 生成、manifest version 同期、E2E 実行補助スクリプト
 
-- `npm test`: stable deterministic tests for parser, API, and content-flow behavior
-- `npm run test:live`: rendered DOM smoke tests against the live Sakura Checker pages
-- `npm run test:e2e-extension`: Playwright Chromium E2E for the unpacked extension on a real Amazon page
-- `npm run test:deploy`: deployment-gate command that runs the deterministic suite plus the live smoke tests
-- `npm run test:browser-compare`: opt-in local investigation only; not part of the default pipeline
+### セットアップ
 
-`npm test` is intended to stay stable across repeated runs. `npm run test:live` and `npm run test:e2e-extension` cover external integration and browser behavior. `npm run test:deploy` is the deployment gate, while `npm run test:browser-compare` stays opt-in for local debugging.
+1. 依存関係をインストールします。
 
-Before the first `npm run test:live` or `npm run test:e2e-extension`, install the Playwright browser once with `npx playwright install chromium`.
+```bash
+npm install
+```
 
-### Browser compare
+2. 初回にライブテストや E2E を動かす場合だけ、Playwright の Chromium をインストールします。
 
-`npm run test:browser-compare` enables the browser comparison test explicitly. It is useful for debugging parser/render drift, but it is not part of the GitHub Actions deployment gate because the upstream page can change between requests.
+```bash
+npx playwright install chromium
+```
+
+3. Chrome で `chrome://extensions/` を開きます。
+4. デベロッパーモードを有効にします。
+5. `パッケージ化されていない拡張機能を読み込む` からこのディレクトリを選びます。
+
+### テスト
+
+用途に応じて次のコマンドを使います。
+
+- `npm test`: 安定した決定論的テスト。パーサー、描画済みスコア抽出、API クライアント、content-flow を検証します
+- `npm run test:live`: Sakura Checker 実ページに対する rendered DOM のスモークテストです
+- `npm run test:e2e-extension`: 実際の Amazon 商品ページを使う Playwright Chromium の拡張 E2E です
+- `npm run test:deploy`: デプロイ前提の確認コマンドです。`npm test` と `npm run test:live` をまとめて実行します
+- `npm run test:browser-compare`: ローカル調査用の opt-in テストです。通常の開発フローや GitHub Actions のデプロイゲートには含めません
+
+`npm test` は繰り返し実行しても安定する前提のテストです。外部サイト依存の確認は `npm run test:live` と `npm run test:e2e-extension` で行います。
+
+### パッケージング
+
+Chrome Web Store 提出用 zip は次のコマンドで作成します。
+
+```bash
+npm run zip
+```
+
+`npm run zip` は `package.json` の version を `manifest.json` に同期したうえで、拡張の実行に必要なファイルだけを含む `extension.zip` をリポジトリ直下へ生成します。
+
+### リリース
+
+Chrome Web Store への提出と GitHub Actions を使った公開フローは [DEPLOYMENT.md](./DEPLOYMENT.md) にまとめています。
+
+リリース前の最小チェック:
+
+- `npm run test:deploy`
+- `npm run zip`
+
+### 関連ドキュメント
+
+- [Chrome Web Store デプロイ手順](./DEPLOYMENT.md)
+- [プライバシーポリシー](./PRIVACY_POLICY.md)
+- [ライセンス](./LICENSE)


### PR DESCRIPTION
## Summary\n- split the README into clear user-facing and developer-facing sections\n- move privacy, permission, communication, and data handling details into the user section\n- consolidate setup, test, packaging, and release guidance in the developer section and align test descriptions with the actual npm scripts\n\n## Validation\n- reviewed the updated README structure and content locally\n- confirmed this is a documentation-only change, so no code tests were run\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- README を「利用者向け」と「開発者向け」に再編し、各対象者が必要な情報を明確に分離した
- 利用者向けセクションにプライバシー、要求権限、外部通信先、chrome.storage.local の保存内容（12時間キャッシュ）と非保存情報を明示し、ユーザーが必要とするセキュリティ・プライバシー情報の透明性を確保した
- 開発者向けセクションに、セットアップ、用途別テストコマンド、npm run zip の役割、リリース前チェック、関連ドキュメント（DEPLOYMENT.md・PRIVACY_POLICY.md）への導線を集約し、開発者が必要な情報を一箇所で参照できるようにした
- Chrome ローカル読み込み手順、重複掲載されたテストコマンド説明、ライセンス本文などの不要な記述を削除し、README の簡潔性を向上させた
- 保存タイミング（DOM 読み取りのための一時タブ作成/即閉じ）の記述位置を保存情報セクションの前後関係に合わせて整理し、情報の流れを改善した

<!-- end of auto-generated comment: release notes by coderabbit.ai -->