### PR TITLE
Fix product page detection and bump version to 2.0.1

### DIFF
--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -1,27 +1,24 @@
 (function () {
+  const PRODUCT_PATH_PATTERN = /\/(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})(?:[/?#]|$)/i;
+
+  function extractAsinFromPath(path) {
+    const match = String(path || "").match(PRODUCT_PATH_PATTERN);
+    return match ? match[1].toUpperCase() : null;
+  }
+
   function extractProductASIN() {
-    const urlMatch = window.location.pathname.match(
-      /\/(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})/i
-    );
-    if (urlMatch) {
-      return urlMatch[1].toUpperCase();
+    const pathAsin = extractAsinFromPath(window.location.pathname);
+    if (pathAsin) {
+      return pathAsin;
     }
 
     const canonical = document.querySelector('link[rel="canonical"]');
     const canonicalHref = canonical && canonical.getAttribute("href");
     if (canonicalHref) {
-      const canonicalMatch = canonicalHref.match(
-        /\/(?:dp|gp\/product)\/([A-Z0-9]{10})/i
-      );
-      if (canonicalMatch) {
-        return canonicalMatch[1].toUpperCase();
+      const canonicalAsin = extractAsinFromPath(canonicalHref);
+      if (canonicalAsin) {
+        return canonicalAsin;
       }
-    }
-
-    const dataAsin = document.querySelector("[data-asin]");
-    const asinValue = dataAsin && dataAsin.getAttribute("data-asin");
-    if (asinValue && /^[A-Z0-9]{10}$/i.test(asinValue)) {
-      return asinValue.toUpperCase();
     }
 
     return null;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "1.0.1",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/parser.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -280,6 +280,33 @@ test("UiDisplay renders the panel after the Amazon title area", () => {
   assert.equal(link.href, "https://sakura-checker.jp/search/B095JGJCC7/");
 });
 
+test("AsinExtractor ignores search result data-asin entries on non-product pages", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/s?k=keyboard");
+  const searchResult = document.createElement("div");
+  searchResult.setAttribute("data-asin", "B095JGJCC7");
+  document.body.appendChild(searchResult);
+
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
+  assert.equal(context.window.AsinExtractor.isProductPage(), false);
+});
+
+test("AsinExtractor reads the canonical product URL when pathname is not a product path", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/gp/aw");
+  const canonical = document.createElement("link");
+  canonical.setAttribute("rel", "canonical");
+  canonical.setAttribute("href", "https://www.amazon.co.jp/gp/aw/d/B095JGJCC7");
+  document.head.appendChild(canonical);
+
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), "B095JGJCC7");
+  assert.equal(context.window.AsinExtractor.isProductPage(), true);
+});
+
 test("SakuraChecker refresh shows loading first and then renders fetched score images", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   let resolveResponse = null;
@@ -335,4 +362,31 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(images[0].src, "data:image/png;base64,AAA");
   assert.equal(images[1].src, "data:image/png;base64,BBB");
   assert.equal(images[2].src, "https://sakura-checker.jp/images/rv_level03.png");
+});
+
+test("SakuraChecker does not render or fetch on non-product pages that contain search-result ASINs", async () => {
+  const document = createPageDocument("https://www.amazon.co.jp/s?k=keyboard");
+  const searchResult = document.createElement("div");
+  searchResult.setAttribute("data-asin", "B095JGJCC7");
+  document.body.appendChild(searchResult);
+
+  let sendMessageCalled = false;
+  const chrome = {
+    runtime: {
+      sendMessage: async () => {
+        sendMessageCalled = true;
+        return { ok: true };
+      },
+    },
+  };
+  const context = createExecutionContext({ document, chrome });
+
+  loadScript(context, "content/asin-extractor.js");
+  loadScript(context, "content/ui-display.js");
+  loadScript(context, "content/sakura-checker.js");
+
+  await context.window.SakuraChecker.refreshForCurrentPage(false);
+
+  assert.equal(sendMessageCalled, false);
+  assert.equal(document.getElementById("sakura-checker-result"), null);
 });


### PR DESCRIPTION
## Summary
- restrict content script activation to actual Amazon product detail URLs or canonical product URLs
- stop treating generic search-result data-asin elements as product-page signals
- bump the extension patch version from 2.0.0 to 2.0.1

## Validation
- npm test

## Assumptions
- Amazon product detail pages expose the ASIN in the path or in a canonical product URL
- pages like search results or buy-again should not activate the extension even if they contain data-asin items


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 商品ページ検出ロジックの修正／検索結果ページなどの非商品ページで `data-asin` 属性が存在する場合に誤検出することを防ぐため、ASINをURL パスと canonical URL に限定して抽出するように変更

- 重複コードの排除／ASINを抽出する正規表現処理を `extractAsinFromPath()` ヘルパー関数に一元化し、保守性を向上

- バージョン更新／修正内容をリリースするため、`manifest.json` と `package.json` のバージョンを 2.0.0 から 2.0.1 に更新

- テストケース追加／新しい検出ロジックが検索結果ページを誤認識しないことと、canonical URL から正しくASINを抽出できることを検証するため、3つの自動テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->