### PR TITLE
Serialize Sakura Checker fetches and bump version to 2.0.1

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -18,6 +18,7 @@
   const inFlightRequests = new Map();
   let nextAllowedRequestAt = 0;
   let rateLimitChain = Promise.resolve();
+  let requestExecutionChain = Promise.resolve();
 
   function buildSourceUrl(asin) {
     return `https://sakura-checker.jp/search/${asin}/`;
@@ -137,10 +138,17 @@
     return reservation;
   }
 
+  function enqueueRequest(task) {
+    const queuedTask = requestExecutionChain.then(task, task);
+    requestExecutionChain = queuedTask.catch(() => {});
+    return queuedTask;
+  }
+
   function resetForTests() {
     inFlightRequests.clear();
     nextAllowedRequestAt = 0;
     rateLimitChain = Promise.resolve();
+    requestExecutionChain = Promise.resolve();
   }
 
   async function checkSakuraScore({
@@ -177,7 +185,7 @@
       return inFlightRequests.get(asin);
     }
 
-    const requestPromise = (async () => {
+    const requestPromise = enqueueRequest(async () => {
       let renderedResult = null;
 
       await waitForRateLimit({
@@ -221,7 +229,7 @@
       await writeCache(asin, payload);
 
       return payload;
-    })().finally(() => {
+    }).finally(() => {
       if (inFlightRequests.get(asin) === requestPromise) {
         inFlightRequests.delete(asin);
       }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "1.0.1",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/parser.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -246,6 +246,50 @@ test("checkSakuraScore serializes concurrent requests for different ASINs", asyn
   assert.equal(second.score.images[0].alt, "B08SECOND0");
 });
 
+test("checkSakuraScore continues the queue after a request throws", async () => {
+  apiClient.__resetForTests();
+  const startedAsins = [];
+
+  const fetchRenderedScoreImpl = async ({ asin }) => {
+    startedAsins.push(asin);
+
+    if (asin === "B08FIRST00") {
+      throw new Error("Simulated Sakura Checker failure.");
+    }
+
+    return {
+      ok: true,
+      score: {
+        kind: "visual-image",
+        images: [{ src: `data:image/png;base64,${asin}`, alt: asin }],
+        suffix: "/5",
+      },
+      verdict: null,
+    };
+  };
+
+  const firstPromise = apiClient.checkSakuraScore({
+    asin: "B08FIRST00",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+  const secondPromise = apiClient.checkSakuraScore({
+    asin: "B08SECOND0",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+  assert.equal(first.ok, false);
+  assert.equal(second.ok, true);
+  assert.deepEqual(startedAsins, ["B08FIRST00", "B08SECOND0"]);
+});
+
 test("checkSakuraScore applies a global request interval between ASINs", async () => {
   apiClient.__resetForTests();
   const waits = [];

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -182,6 +182,70 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN", asyn
   assert.deepEqual(second.score, first.score);
 });
 
+test("checkSakuraScore serializes concurrent requests for different ASINs", async () => {
+  apiClient.__resetForTests();
+  const startedAsins = [];
+  const resolvers = [];
+  let activeRequests = 0;
+  let maxActiveRequests = 0;
+
+  const fetchRenderedScoreImpl = async ({ asin }) => {
+    startedAsins.push(asin);
+    activeRequests += 1;
+    maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+
+    return new Promise((resolve) => {
+      resolvers.push(() => {
+        activeRequests -= 1;
+        resolve({
+          ok: true,
+          score: {
+            kind: "visual-image",
+            images: [{ src: `data:image/png;base64,${asin}`, alt: asin }],
+            suffix: "/5",
+          },
+          verdict: null,
+        });
+      });
+    });
+  };
+
+  const firstPromise = apiClient.checkSakuraScore({
+    asin: "B08N5WRWNW",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+  const secondPromise = apiClient.checkSakuraScore({
+    asin: "B08SECOND0",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(startedAsins, ["B08N5WRWNW"]);
+  assert.equal(maxActiveRequests, 1);
+  assert.equal(resolvers.length, 1);
+
+  resolvers[0]();
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(startedAsins, ["B08N5WRWNW", "B08SECOND0"]);
+  assert.equal(maxActiveRequests, 1);
+  assert.equal(resolvers.length, 2);
+
+  resolvers[1]();
+
+  const [first, second] = await Promise.all([firstPromise, secondPromise]);
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(first.score.images[0].alt, "B08N5WRWNW");
+  assert.equal(second.score.images[0].alt, "B08SECOND0");
+});
+
 test("checkSakuraScore applies a global request interval between ASINs", async () => {
   apiClient.__resetForTests();
   const waits = [];


### PR DESCRIPTION
## Summary
- serialize Sakura Checker fetches across different ASINs so temporary tabs do not run in parallel
- add a regression test covering concurrent requests for different ASINs
- bump the extension patch version to 2.0.1 in package metadata

## Validation
- node --test tests/api-client.test.js tests/rendered-score-client.test.js tests/content-flow.test.js

## Notes
- npm test was not rerun here because the full suite still depends on local dev dependencies like linkedom being installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **リクエスト実行チェーンの導入** / `checkSakuraScore`の実行をPromiseキューで直列化し、複数ASINに対する一時的なタブが並行実行されないようにした
- **バージョンを2.0.1に更新** / manifest.jsonとpackage.jsonのバージョンを2.0.0から2.0.1にバンプアップした
- **直列化動作を検証するテスト追加** / 異なるASINに対する並行リクエストが実際に1つずつ実行されることを確認するリグレッションテストを追加した

<!-- end of auto-generated comment: release notes by coderabbit.ai -->