### PR TITLE
Fix Sakura score card selection and bump version to 2.0.2

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -61,6 +61,34 @@
     return { ok: false, code, message, sourceUrl };
   }
 
+  function hasValidScoreImage(image) {
+    return Boolean(
+      image &&
+      typeof image === "object" &&
+      typeof image.src === "string" &&
+      image.src.trim()
+    );
+  }
+
+  function hasValidScorePayload(score) {
+    return Boolean(
+      score &&
+      typeof score === "object" &&
+      Array.isArray(score.images) &&
+      score.images.length > 0 &&
+      score.images.every(hasValidScoreImage) &&
+      typeof score.suffix === "string"
+    );
+  }
+
+  function hasValidSuccessPayload(payload) {
+    return Boolean(
+      payload &&
+      payload.ok === true &&
+      hasValidScorePayload(payload.score)
+    );
+  }
+
   function hasStorage() {
     return (
       typeof chrome !== "undefined" &&
@@ -101,6 +129,10 @@
 
     const fetchedAt = Date.parse(cachedValue.fetchedAt);
     if (Number.isNaN(fetchedAt) || Date.now() - fetchedAt > CACHE_TTL_MS) {
+      return null;
+    }
+
+    if (!hasValidSuccessPayload(cachedValue)) {
       return null;
     }
 
@@ -205,6 +237,14 @@
           renderedResult && renderedResult.message
             ? renderedResult.message
             : "Could not extract a rendered Sakura Checker score.",
+          sourceUrl
+        );
+      }
+
+      if (!hasValidSuccessPayload(renderedResult)) {
+        return createFailure(
+          "parse_error",
+          "The rendered Sakura Checker response did not include a usable score.",
           sourceUrl
         );
       }

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -178,6 +178,10 @@
     }
 
     function getLegacyCandidateData(itemInfo) {
+      const reviewCountText = normalizeText(
+        (itemInfo.querySelector(".item-num .boldtxt") || {}).textContent || ""
+      );
+      const reviewCount = Number(reviewCountText.replace(/[^\d]/g, "")) || 0;
       const ratingNodes = itemInfo.querySelectorAll("p.item-rating");
       const images = getRatingImages(ratingNodes);
       if (!images.length) {
@@ -211,6 +215,7 @@
 
       return {
         score,
+        reviewCount,
         scorePayload: {
           kind: "visual-image",
           images,
@@ -250,7 +255,11 @@
             return candidate;
           }
 
-          return candidate.score > best.score ? candidate : best;
+          if (candidate.score !== best.score) {
+            return candidate.score > best.score ? candidate : best;
+          }
+
+          return candidate.reviewCount > best.reviewCount ? candidate : best;
         }, null);
 
       if (!bestCandidate) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/parser.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -102,6 +102,48 @@ test("checkSakuraScore caches successful rendered responses", async () => {
   }
 });
 
+test("checkSakuraScore ignores malformed cached successes and refetches", async () => {
+  apiClient.__resetForTests();
+  const cleanup = installChromeStorageStub();
+  let fetchRenderedScoreCalls = 0;
+
+  try {
+    await apiClient.writeCache("B08N5WRWNW", {
+      ok: true,
+      fetchedAt: new Date().toISOString(),
+      sourceUrl: "https://sakura-checker.jp/search/B08N5WRWNW/",
+      score: null,
+      verdict: null,
+    });
+
+    const result = await apiClient.checkSakuraScore({
+      asin: "B08N5WRWNW",
+      forceRefresh: false,
+      fetchRenderedScoreImpl: async () => {
+        fetchRenderedScoreCalls += 1;
+        return {
+          ok: true,
+          score: {
+            kind: "visual-image",
+            images: [{ src: "data:image/png;base64,AAAA", alt: "score" }],
+            suffix: "/5",
+          },
+          verdict: null,
+        };
+      },
+      waitImpl: async () => {},
+      randomImpl: () => 0,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.cached, false);
+    assert.equal(result.score.images.length, 1);
+    assert.equal(fetchRenderedScoreCalls, 1);
+  } finally {
+    cleanup();
+  }
+});
+
 test("checkSakuraScore returns blocked when rendered extraction is blocked", async () => {
   apiClient.__resetForTests();
   const result = await apiClient.checkSakuraScore({
@@ -118,6 +160,28 @@ test("checkSakuraScore returns blocked when rendered extraction is blocked", asy
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "blocked");
+});
+
+test("checkSakuraScore rejects successful responses that do not include a usable score", async () => {
+  apiClient.__resetForTests();
+  const result = await apiClient.checkSakuraScore({
+    asin: "B08N5WRWNW",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async () => ({
+      ok: true,
+      score: {
+        kind: "visual-image",
+        images: [],
+        suffix: "/5",
+      },
+      verdict: null,
+    }),
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "parse_error");
 });
 
 test("checkSakuraScore returns not_found when the product is missing", async () => {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -332,6 +332,62 @@ const wrapperScopedLegacyHtml = `
   </html>
 `;
 
+const repeatedDigitImageTag = '<img src="data:image/png;base64,LOWDIGIT" alt="repeat-digit">';
+const narrowSeparatorImageTag = '<img src="data:image/png;base64,SEPARATOR" alt="separator">';
+const distinctLargeImageTag = '<img src="data:image/png;base64,HIGH-A" alt="distinct-large">';
+const distinctWideImageTag = '<img src="data:image/png;base64,HIGH-B" alt="distinct-wide">';
+const distinctMediumImageTag = '<img src="data:image/png;base64,HIGH-C" alt="distinct-medium">';
+const distinctTailImageTag = '<img src="data:image/png;base64,HIGH-D" alt="distinct-tail">';
+
+const lowCountLegacyItemInfo = `
+  <div class="item-info low-count">
+    <div class="item-review-box">
+      <div class="item-review-after">
+        <p class="item-logo"><img src="/images/logo_s.png" alt="logo"></p>
+        <p class="item-rating"><span>${repeatedDigitImageTag}${narrowSeparatorImageTag}${repeatedDigitImageTag}${repeatedDigitImageTag}${repeatedDigitImageTag}</span>/5</p>
+        <p class="item-num"><span class="boldtxt">142件</span>の評価</p>
+      </div>
+      <div class="item-review-level">
+        <p class="item-rv-lv item-rv-lv04"><img src="/images/rv_level04.png" alt="lower"></p>
+        <p class="item-rv-score">Amazonより<br>かなり低いスコア</p>
+        <a href="https://www.amazon.co.jp/gp/customer-reviews/R5JSDCZSAXGHW7/" class="button button-blue button-mini" target="_blank" rel="nofollow">サゲ評価</a>
+      </div>
+    </div>
+  </div>
+`;
+
+const highCountLegacyItemInfo = `
+  <div class="item-info high-count">
+    <div class="item-review-box">
+      <div class="item-review-after">
+        <p class="item-logo"><img src="/images/logo_s.png" alt="logo"></p>
+        <p class="item-rating"><span>${distinctLargeImageTag}${narrowSeparatorImageTag}${distinctWideImageTag}${distinctMediumImageTag}${distinctTailImageTag}</span>/5</p>
+        <p class="item-num"><span class="boldtxt">18177件</span>の評価</p>
+      </div>
+      <div class="item-review-level">
+        <p class="item-rv-lv item-rv-lv01"><img src="/images/rv_level01.png" alt="higher"></p>
+        <p class="item-rv-score">Amazonと<br>同等のスコア</p>
+        <a href="https://www.amazon.co.jp/gp/customer-reviews/R194PYLE36254E/" class="button button-blue button-mini" target="_blank" rel="nofollow">高評価</a>
+      </div>
+    </div>
+  </div>
+`;
+
+const sameWrapReviewCountTiebreakHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div class="item-review-wrap">
+        <div class="item-image">
+          <a href="https://www.amazon.co.jp/dp/B095JGJCC7/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+        </div>
+        ${lowCountLegacyItemInfo}
+        ${highCountLegacyItemInfo}
+      </div>
+    </body>
+  </html>
+`;
+
 const renderedModernWithUnrelatedLegacyHtml = `
   <!DOCTYPE html>
   <html lang="ja">
@@ -512,6 +568,7 @@ module.exports = {
   renderedModernHtml,
   sampleHtml,
   sampleImageTag,
+  sameWrapReviewCountTiebreakHtml,
   scrambledScoreValue,
   targetedRenderedLoadingHtml,
   targetedRenderedProductHtml,

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -70,6 +70,20 @@ test("extractRenderedScore does not treat sibling cards as ASIN matches via the 
   assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level03.png");
 });
 
+test("extractRenderedScore prefers the highest-review legacy card when wrapper-scoped siblings tie structurally", () => {
+  const document = parseDocument(fixtures.sameWrapReviewCountTiebreakHtml);
+  const result = renderedParser.extractRenderedScore(document, "B095JGJCC7");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.suffix, "/5");
+  assert.deepEqual(
+    result.score.images.map((image) => image.alt),
+    ["distinct-large", "separator", "distinct-wide", "distinct-medium", "distinct-tail"]
+  );
+  assert.ok(result.verdict);
+  assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level01.png");
+});
+
 test("extractRenderedScore waits when only unrelated legacy cards are rendered for the requested ASIN", () => {
   const document = parseDocument(fixtures.targetedRenderedLoadingHtml);
   const result = renderedParser.extractRenderedScore(document, "B0TARGET42");


### PR DESCRIPTION
## Summary
- fix legacy rendered score selection so the extension chooses the intended high-review Sakura Checker card when multiple cards share one wrapper
- reject malformed successful score payloads so empty score data is not treated as a valid fetch result
- bump the extension patch version from 2.0.1 to 2.0.2 in package.json, package-lock.json, and manifest.json

## Validation
- npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **スコアペイロード検証の追加**: 空のスコアデータを無視するため、キャッシュ読み込み時とAPI応答時に`hasValidScorePayload`等の検証ヘルパーを追加し、不正な形式のペイロードを`parse_error`として処理するようにした。

- **レガシースコアカード選択の改善**: 同じラッパー内で複数のカードが存在する場合にスコアが同じ時、レビュー数（`reviewCount`）が多いカードを選ぶようにタイブレーク処理を実装した。

- **バージョン2.0.2への更新**: manifest.json、package.json、package-lock.jsonのバージョン番号を2.0.1から2.0.2に更新した。

- **テストケースの追加**: 不正なキャッシュエントリが無視されることと、無効なスコアペイロードがparse_errorを返すこと、およびレビュー数のタイブレーク処理が正しく動作することを検証するテストを追加した。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->