### PR TITLE
Prioritize itemsearch scoring while preserving legacy fallback behavior

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -20,7 +20,23 @@
   let rateLimitChain = Promise.resolve();
   let requestExecutionChain = Promise.resolve();
 
+  function encodeItemSearchWord(value) {
+    const normalizedValue = String(value || "");
+    if (typeof btoa === "function") {
+      return btoa(normalizedValue);
+    }
+    if (typeof Buffer !== "undefined") {
+      return Buffer.from(normalizedValue, "utf8").toString("base64");
+    }
+
+    throw new Error("No Base64 encoder is available.");
+  }
+
   function buildSourceUrl(asin) {
+    return `https://sakura-checker.jp/itemsearch/?word=${encodeItemSearchWord(asin)}`;
+  }
+
+  function buildDetailUrl(asin) {
     return `https://sakura-checker.jp/search/${asin}/`;
   }
 
@@ -72,14 +88,23 @@
   }
 
   function hasValidScorePayload(score) {
-    return Boolean(
-      score &&
-      typeof score === "object" &&
-      Array.isArray(score.images) &&
-      score.images.length > 0 &&
-      score.images.every(hasValidScoreImage) &&
-      typeof score.suffix === "string"
-    );
+    if (!score || typeof score !== "object" || typeof score.suffix !== "string") {
+      return false;
+    }
+
+    if (score.kind === "visual-image") {
+      return Boolean(
+        Array.isArray(score.images) &&
+        score.images.length > 0 &&
+        score.images.every(hasValidScoreImage)
+      );
+    }
+
+    if (score.kind === "text") {
+      return typeof score.value === "string" && score.value.trim().length > 0;
+    }
+
+    return false;
   }
 
   function hasValidSuccessPayload(payload) {
@@ -137,7 +162,10 @@
       return null;
     }
 
-    return cachedValue;
+    return {
+      ...cachedValue,
+      sourceUrl: buildDetailUrl(asin),
+    };
   }
 
   async function writeCache(asin, payload) {
@@ -191,7 +219,8 @@
     randomImpl,
     waitImpl,
   }) {
-    const sourceUrl = buildSourceUrl(asin);
+    const requestUrl = buildSourceUrl(asin);
+    const sourceUrl = buildDetailUrl(asin);
 
     if (!RenderedScoreClient && typeof fetchRenderedScoreImpl !== "function") {
       return createFailure(
@@ -229,7 +258,7 @@
       try {
         renderedResult = await fetchRenderedScore({
           asin,
-          sourceUrl,
+          sourceUrl: requestUrl,
         });
       } catch (error) {
         return createFailure(
@@ -281,9 +310,11 @@
 
   return {
     __resetForTests: resetForTests,
+    buildDetailUrl,
     buildSourceUrl,
     checkSakuraScore,
     createFailure,
+    encodeItemSearchWord,
     readCache,
     writeCache,
   };

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -107,6 +107,20 @@
         .filter(Boolean);
     }
 
+    function createTextVerdict(lines) {
+      const normalizedLines = Array.isArray(lines)
+        ? lines.map(normalizeText).filter(Boolean)
+        : [];
+      if (!normalizedLines.length) {
+        return null;
+      }
+
+      return {
+        kind: "text-verdict",
+        lines: normalizedLines,
+      };
+    }
+
     function buildRequestedAsinPattern() {
       if (!requestedAsin) {
         return null;
@@ -130,35 +144,38 @@
       );
     }
 
-    function anchorContainsAnyAsin(anchor) {
-      if (!anchor) {
-        return false;
+    function getDirectChildItemInfos(reviewWrap) {
+      if (!reviewWrap || !reviewWrap.children) {
+        return [];
       }
 
-      return /(?:\/dp\/|\/gp\/product\/|\/search\/)[A-Z0-9]{10}/i.test(
-        String(anchor.getAttribute("href") || anchor.href || "")
+      return Array.from(reviewWrap.children).filter(
+        (child) =>
+          child &&
+          typeof child.matches === "function" &&
+          child.matches(".item-info")
       );
     }
 
-    function matchesRequestedAsin(itemInfo) {
+    function reviewWrapMatchesRequestedAsin(reviewWrap) {
+      if (!requestedAsinPattern || !reviewWrap) {
+        return false;
+      }
+
+      return Array.from(reviewWrap.querySelectorAll("a[href]")).some(anchorMatchesRequestedAsin);
+    }
+
+    function hasExactRequestedAsinMatch(itemInfo) {
       if (!requestedAsin) {
-        return true;
+        return false;
       }
 
       const ownAnchors = Array.from(itemInfo.querySelectorAll("a[href]"));
       if (ownAnchors.some(anchorMatchesRequestedAsin)) {
         return true;
       }
-      if (ownAnchors.some(anchorContainsAnyAsin)) {
-        return false;
-      }
 
-      const reviewWrap = itemInfo.closest(".item-review-wrap");
-      if (!reviewWrap) {
-        return false;
-      }
-
-      return Array.from(reviewWrap.querySelectorAll("a[href]")).some(anchorMatchesRequestedAsin);
+      return String(itemInfo.outerHTML || "").includes(requestedAsin);
     }
 
     function hasPendingRequestedLegacyCard() {
@@ -232,7 +249,8 @@
       };
     }
 
-    function extractLegacyScore() {
+    function extractLegacyScore(options = {}) {
+      const allowAmbiguousMatches = Boolean(options.allowAmbiguousMatches);
       const seen = new Set();
       const candidates = Array.from(
         root.querySelectorAll(".item-review-wrap .item-info, .item-info")
@@ -244,8 +262,42 @@
         return true;
       });
 
-      const matchingCandidates = candidates.filter(matchesRequestedAsin);
-      const scopedCandidates = requestedAsin ? matchingCandidates : candidates;
+      let scopedCandidates = candidates;
+      let matchingCandidates = candidates;
+
+      if (requestedAsin) {
+        const matchingWraps = Array.from(root.querySelectorAll(".item-review-wrap")).filter(
+          reviewWrapMatchesRequestedAsin
+        );
+
+        const exactCandidates = matchingWraps.flatMap((reviewWrap) =>
+          getDirectChildItemInfos(reviewWrap).filter(hasExactRequestedAsinMatch)
+        );
+
+        if (exactCandidates.length) {
+          matchingCandidates = exactCandidates;
+          scopedCandidates = exactCandidates;
+        } else {
+          const ambiguousWrapCandidates = matchingWraps.flatMap((reviewWrap) =>
+            getDirectChildItemInfos(reviewWrap)
+          );
+          const singleCardWrapCandidates = matchingWraps
+            .map((reviewWrap) => getDirectChildItemInfos(reviewWrap))
+            .filter((itemInfos) => itemInfos.length === 1)
+            .map((itemInfos) => itemInfos[0]);
+
+          if (singleCardWrapCandidates.length) {
+            matchingCandidates = singleCardWrapCandidates;
+            scopedCandidates = singleCardWrapCandidates;
+          } else if (allowAmbiguousMatches && ambiguousWrapCandidates.length) {
+            matchingCandidates = ambiguousWrapCandidates;
+            scopedCandidates = ambiguousWrapCandidates;
+          } else {
+            matchingCandidates = [];
+            scopedCandidates = [];
+          }
+        }
+      }
 
       const bestCandidate = scopedCandidates
         .map(getLegacyCandidateData)
@@ -279,6 +331,60 @@
         ok: true,
         score: bestCandidate.scorePayload,
         verdict: bestCandidate.verdict,
+      };
+    }
+
+    function extractItemSearchScore() {
+      const candidates = Array.from(root.querySelectorAll('[name="searchitem"]'));
+      if (!candidates.length) {
+        return null;
+      }
+
+      const matchingCandidate = candidates.find((candidate) => {
+        if (!requestedAsinPattern) {
+          return true;
+        }
+
+        return Array.from(candidate.querySelectorAll("a[href]")).some(anchorMatchesRequestedAsin);
+      });
+
+      if (!matchingCandidate) {
+        return null;
+      }
+
+      const scoreNode = matchingCandidate.querySelector(".item-info .item-rating, .item-rating");
+      const scoreText = normalizeText((scoreNode || {}).textContent || "");
+      const scoreMatch = scoreText.match(/([0-9]+(?:\.[0-9]+)?)\s*\/\s*5/i);
+      if (!scoreMatch) {
+        return null;
+      }
+
+      const sakuraPercentText = normalizeText(
+        (
+          matchingCandidate.querySelector(".item-info .item-sakura .is-size-7, .item-sakura .is-size-7") ||
+          {}
+        ).textContent || ""
+      );
+      const levelText = normalizeText(
+        (matchingCandidate.querySelector(".item-info .item-lv, .item-lv") || {}).textContent || ""
+      );
+
+      const verdictLines = [];
+      if (levelText) {
+        verdictLines.push(levelText);
+      }
+      if (sakuraPercentText) {
+        verdictLines.push(`サクラ度 ${sakuraPercentText}`);
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: scoreMatch[1],
+          suffix: "/5",
+        },
+        verdict: createTextVerdict(verdictLines),
       };
     }
 
@@ -406,6 +512,11 @@
       };
     }
 
+    const itemSearch = extractItemSearchScore();
+    if (itemSearch) {
+      return itemSearch;
+    }
+
     const legacy = extractLegacyScore();
     if (legacy && legacy.ok) {
       return legacy;
@@ -417,6 +528,11 @@
     const modern = extractModernScore();
     if (modern) {
       return modern;
+    }
+
+    const ambiguousLegacy = extractLegacyScore({ allowAmbiguousMatches: true });
+    if (ambiguousLegacy && ambiguousLegacy.ok) {
+      return ambiguousLegacy;
     }
 
     const hasLoadingSignals = Boolean(

--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -70,6 +70,13 @@
         display: block;
       }
 
+      #${ROOT_ID} .sc-score-text {
+        font-size: 28px;
+        line-height: 1;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
       #${ROOT_ID} .sc-suffix {
         font-size: 18px;
         font-weight: 700;
@@ -87,6 +94,13 @@
         max-height: 32px;
         width: auto;
         display: block;
+      }
+
+      #${ROOT_ID} .sc-verdict-text {
+        font-size: 13px;
+        font-weight: 700;
+        color: #565959;
+        white-space: nowrap;
       }
 
       #${ROOT_ID} .sc-status-value {
@@ -197,17 +211,26 @@
   }
 
   function createVerdictNode(verdict) {
-    if (!verdict || !verdict.image) {
+    if (!verdict || (!verdict.image && (!verdict.lines || !verdict.lines.length))) {
       return null;
     }
 
     const verdictNode = document.createElement("div");
     verdictNode.className = "sc-verdict";
 
-    const icon = document.createElement("img");
-    icon.src = verdict.image.src;
-    icon.alt = verdict.image.alt || "サクラチェッカーの判定";
-    verdictNode.appendChild(icon);
+    if (verdict.image) {
+      const icon = document.createElement("img");
+      icon.src = verdict.image.src;
+      icon.alt = verdict.image.alt || "サクラチェッカーの判定";
+      verdictNode.appendChild(icon);
+    }
+
+    if (Array.isArray(verdict.lines) && verdict.lines.length) {
+      const text = document.createElement("span");
+      text.className = "sc-verdict-text";
+      text.textContent = verdict.lines.join(" / ");
+      verdictNode.appendChild(text);
+    }
 
     return verdictNode;
   }
@@ -218,6 +241,25 @@
 
     if (!score) {
       value.textContent = "-";
+      return value;
+    }
+
+    if (score.kind === "text") {
+      const scoreText = document.createElement("span");
+      scoreText.className = "sc-score-text";
+      scoreText.textContent = score.value;
+      value.appendChild(scoreText);
+
+      const suffix = document.createElement("span");
+      suffix.className = "sc-suffix";
+      suffix.textContent = score.suffix;
+      value.appendChild(suffix);
+
+      const textVerdict = createVerdictNode(verdict);
+      if (textVerdict) {
+        value.appendChild(textVerdict);
+      }
+
       return value;
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/scripts/run-extension-e2e.js
+++ b/scripts/run-extension-e2e.js
@@ -49,6 +49,14 @@ const SETTLE_TIMEOUT_MS = Number(process.env.SAKURA_E2E_TIMEOUT_MS || 45000);
 const EXPECTED_SUFFIX = process.env.SAKURA_E2E_EXPECT_SUFFIX || "/5";
 const HEADLESS = process.env.PW_EXTENSION_HEADLESS !== "0";
 
+function encodeItemSearchWord(value) {
+  return Buffer.from(String(value || ""), "utf8").toString("base64");
+}
+
+function isSupportedSuffix(value) {
+  return value === "/5" || value === "%";
+}
+
 function ensureOutputDir() {
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
 }
@@ -87,6 +95,8 @@ async function collectPanelState(page) {
       alt: image.getAttribute("alt") || "",
     }));
     const verdictImageNode = root.querySelector(".sc-verdict img");
+    const verdictTextNode = root.querySelector(".sc-verdict-text");
+    const scoreTextNode = root.querySelector(".sc-score-text");
     const suffixNode = root.querySelector(".sc-suffix");
 
     return {
@@ -95,6 +105,7 @@ async function collectPanelState(page) {
       linkHref: link ? link.href : null,
       scoreImageCount: scoreImages.length,
       scoreImages,
+      scoreText: scoreTextNode ? scoreTextNode.textContent || "" : "",
       scoreSuffix: suffixNode ? suffixNode.textContent || "" : "",
       verdictImage: verdictImageNode
         ? {
@@ -102,6 +113,7 @@ async function collectPanelState(page) {
             alt: verdictImageNode.getAttribute("alt") || "",
           }
         : null,
+      verdictText: verdictTextNode ? verdictTextNode.textContent || "" : "",
       url: location.href,
       title: document.title,
     };
@@ -148,10 +160,14 @@ async function run() {
     if (!panel.linkHref || !panel.linkHref.includes(expectedLink)) {
       throw new Error(`Unexpected panel link: ${panel.linkHref || "<missing>"}`);
     }
-    if (panel.scoreImageCount < 1) {
-      throw new Error("The Sakura Checker panel did not render any score images.");
+    if (panel.scoreImageCount < 1 && !panel.scoreText) {
+      throw new Error("The Sakura Checker panel did not render a score.");
     }
-    if (panel.scoreSuffix !== EXPECTED_SUFFIX) {
+    if (process.env.SAKURA_E2E_EXPECT_SUFFIX) {
+      if (panel.scoreSuffix !== EXPECTED_SUFFIX) {
+        throw new Error(`Unexpected score suffix: ${panel.scoreSuffix || "<missing>"}`);
+      }
+    } else if (!isSupportedSuffix(panel.scoreSuffix)) {
       throw new Error(`Unexpected score suffix: ${panel.scoreSuffix || "<missing>"}`);
     }
 

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -37,8 +37,20 @@ test("buildSourceUrl creates the Sakura Checker search URL", () => {
   apiClient.__resetForTests();
   assert.equal(
     apiClient.buildSourceUrl("B08N5WRWNW"),
+    "https://sakura-checker.jp/itemsearch/?word=QjA4TjVXUldOVw=="
+  );
+});
+
+test("buildDetailUrl creates the Sakura Checker detail URL", () => {
+  apiClient.__resetForTests();
+  assert.equal(
+    apiClient.buildDetailUrl("B08N5WRWNW"),
     "https://sakura-checker.jp/search/B08N5WRWNW/"
   );
+});
+
+test("encodeItemSearchWord base64-encodes the ASIN", () => {
+  assert.equal(apiClient.encodeItemSearchWord("B091BGMKYS"), "QjA5MUJHTUtZUw==");
 });
 
 test("checkSakuraScore caches successful rendered responses", async () => {
@@ -84,6 +96,7 @@ test("checkSakuraScore caches successful rendered responses", async () => {
 
     assert.equal(first.ok, true);
     assert.equal(first.cached, false);
+    assert.equal(first.sourceUrl, "https://sakura-checker.jp/search/B08N5WRWNW/");
     assert.deepEqual(first.verdict, {
       kind: "visual-verdict",
       image: {
@@ -111,7 +124,7 @@ test("checkSakuraScore ignores malformed cached successes and refetches", async 
     await apiClient.writeCache("B08N5WRWNW", {
       ok: true,
       fetchedAt: new Date().toISOString(),
-      sourceUrl: "https://sakura-checker.jp/search/B08N5WRWNW/",
+      sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjA4TjVXUldOVw==",
       score: null,
       verdict: null,
     });
@@ -182,6 +195,33 @@ test("checkSakuraScore rejects successful responses that do not include a usable
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "parse_error");
+});
+
+test("checkSakuraScore accepts text-based itemsearch scores", async () => {
+  apiClient.__resetForTests();
+  const result = await apiClient.checkSakuraScore({
+    asin: "B091BGMKYS",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async () => ({
+      ok: true,
+      score: {
+        kind: "text",
+        value: "1.93",
+        suffix: "/5",
+      },
+      verdict: {
+        kind: "text-verdict",
+        lines: ["危険", "サクラ度 90%"],
+      },
+    }),
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "text");
+  assert.equal(result.score.value, "1.93");
+  assert.equal(result.sourceUrl, "https://sakura-checker.jp/search/B091BGMKYS/");
 });
 
 test("checkSakuraScore returns not_found when the product is missing", async () => {

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -245,6 +245,15 @@ function findImages(root) {
   return images;
 }
 
+function findByClass(root, className) {
+  return findFirst(root, (element) =>
+    String(element.className || "")
+      .split(/\s+/)
+      .filter(Boolean)
+      .includes(className)
+  );
+}
+
 test("content.js initializes SakuraChecker immediately after document_end", () => {
   const document = new FakeDocument({
     url: "https://www.amazon.co.jp/dp/B095JGJCC7",
@@ -268,7 +277,9 @@ test("UiDisplay renders the panel after the Amazon title area", () => {
   const context = createExecutionContext({ document });
   loadScript(context, "content/ui-display.js");
 
-  context.window.UiDisplay.renderLoading("https://sakura-checker.jp/search/B095JGJCC7/");
+  context.window.UiDisplay.renderLoading(
+    "https://sakura-checker.jp/itemsearch/?word=QjA5NUpHSkNDNw=="
+  );
 
   const root = document.getElementById("sakura-checker-result");
   assert.ok(root);
@@ -277,7 +288,7 @@ test("UiDisplay renders the panel after the Amazon title area", () => {
 
   const link = findFirst(root, (element) => element.tagName === "A");
   assert.ok(link);
-  assert.equal(link.href, "https://sakura-checker.jp/search/B095JGJCC7/");
+  assert.equal(link.href, "https://sakura-checker.jp/itemsearch/?word=QjA5NUpHSkNDNw==");
 });
 
 test("AsinExtractor ignores search result data-asin entries on non-product pages", () => {
@@ -335,7 +346,7 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   resolveResponse.resolve({
     ok: true,
     cached: false,
-    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjA5NUpHSkNDNw==",
     score: {
       kind: "visual-image",
       suffix: "/5",
@@ -362,6 +373,39 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(images[0].src, "data:image/png;base64,AAA");
   assert.equal(images[1].src, "data:image/png;base64,BBB");
   assert.equal(images[2].src, "https://sakura-checker.jp/images/rv_level03.png");
+});
+
+test("UiDisplay renders text-based itemsearch scores", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B091BGMKYS");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess({
+    ok: true,
+    cached: false,
+    sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjA5MUJHTUtZUw==",
+    score: {
+      kind: "text",
+      value: "1.93",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["危険", "サクラ度 90%"],
+    },
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  assert.ok(root);
+  assert.equal(root.dataset.state, "success");
+
+  const scoreText = findByClass(root, "sc-score-text");
+  assert.ok(scoreText);
+  assert.equal(scoreText.textContent, "1.93");
+
+  const verdictText = findByClass(root, "sc-verdict-text");
+  assert.ok(verdictText);
+  assert.equal(verdictText.textContent, "危険 / サクラ度 90%");
 });
 
 test("SakuraChecker does not render or fetch on non-product pages that contain search-result ASINs", async () => {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -444,6 +444,25 @@ const fixedRenderedModernWithUnrelatedLegacyHtml = `
   </html>
 `;
 
+const ambiguousWrapperWithModernHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div class="item-review-wrap">
+        <div class="item-image">
+          <a href="https://www.amazon.co.jp/dp/B095JGJCC7/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+        </div>
+        ${lowCountLegacyItemInfo}
+        ${highCountLegacyItemInfo}
+      </div>
+      <div class="sakuraBlock">
+        ${modernSakuraAlertMarkup}
+        ${modernSakuraRatingMarkup}
+      </div>
+    </body>
+  </html>
+`;
+
 const modernInjectedHtml = `
   <!DOCTYPE html>
   <html lang="ja">
@@ -520,6 +539,35 @@ const renderedBlockedHtml = `
   </html>
 `;
 
+const itemSearchResultHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div class="list-wrap marginsideless-sp">
+        <div name="searchitem" sakura="90">
+          <div class="is-flex list-box">
+            <div class="list-item-image">
+              <a href="https://www.amazon.co.jp/dp/B091BGMKYS?tag=sakurachecker-22&linkCode=osi&th=1&psc=1" target="_blank" class="linkimg"></a>
+            </div>
+            <div class="list-info">
+              <p class="item-name">
+                UGREEN Nexode 65W
+                <a href="https://www.amazon.co.jp/dp/B091BGMKYS?tag=sakurachecker-22&linkCode=osi&th=1&psc=1" rel="nofollow" target="_blank">...</a>
+              </p>
+              <p class="item-info">
+                <span class="item-rating"><span>1.93</span>/5</span>
+                <span class="item-rvnum">(7844件)</span>
+                <span class="item-sakura">サクラ度<span class="is-size-7">90%</span></span>
+                <span class="item-lv item-lv04">危険</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </body>
+  </html>
+`;
+
 const productAndModernHtml = sampleHtml.replace(
   "</body>",
   `
@@ -544,10 +592,12 @@ const productAndModernHtml = sampleHtml.replace(
 );
 
 module.exports = {
+  ambiguousWrapperWithModernHtml,
   comparisonHeavyProductHtml,
   comparisonPrimaryItemInfo,
   comparisonSecondaryItemInfo,
   htmlWithInjectedScore,
+  itemSearchResultHtml,
   injectedDecodedScript,
   injectedPayload,
   injectedScoreMarkup,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -38,6 +38,10 @@ function formatFailure(asin, result, error) {
   return parts.join(" ");
 }
 
+function isSupportedSuffix(value) {
+  return value === "/5" || value === "%";
+}
+
 async function extractRenderedScore(page, asin) {
   return page.evaluate(({ extractSource, asin: requestedAsin }) => {
     const extract = Function(`return (${extractSource});`)();
@@ -100,7 +104,7 @@ async function runLiveSmokeWithRetry(asin) {
 
       assert.equal(result.ok, true, formatFailure(asin, result));
       assert.equal(result.score.kind, "visual-image", formatFailure(asin, result));
-      assert.equal(result.score.suffix, "/5", formatFailure(asin, result));
+      assert.equal(isSupportedSuffix(result.score.suffix), true, formatFailure(asin, result));
       assert.ok(result.score.images.length >= 1, formatFailure(asin, result));
 
       for (const image of result.score.images) {
@@ -125,7 +129,7 @@ async function runLiveSmokeWithRetry(asin) {
 }
 
 for (const asin of knownAsins) {
-  test(`live smoke returns rendered /5 score images for ${asin}`, { timeout: liveSmokeTestTimeoutMs }, async () => {
+  test(`live smoke returns rendered score images for ${asin}`, { timeout: liveSmokeTestTimeoutMs }, async () => {
     await runLiveSmokeWithRetry(asin);
   });
 }

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -28,6 +28,20 @@ test("extractRenderedScore reads the legacy /5 product card with verdict", () =>
   assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level03.png");
 });
 
+test("extractRenderedScore reads the itemsearch row for the requested ASIN", () => {
+  const document = parseDocument(
+    fixtures.itemSearchResultHtml,
+    "https://sakura-checker.jp/itemsearch/?word=QjA5MUJHTUtZUw=="
+  );
+  const result = renderedParser.extractRenderedScore(document, "B091BGMKYS");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "text");
+  assert.equal(result.score.value, "1.93");
+  assert.equal(result.score.suffix, "/5");
+  assert.deepEqual(result.verdict.lines, ["危険", "サクラ度 90%"]);
+});
+
 test("extractRenderedScore prefers the richest rendered product card", () => {
   const document = parseDocument(fixtures.comparisonHeavyProductHtml);
   const result = renderedParser.extractRenderedScore(document);
@@ -70,7 +84,7 @@ test("extractRenderedScore does not treat sibling cards as ASIN matches via the 
   assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level03.png");
 });
 
-test("extractRenderedScore prefers the highest-review legacy card when wrapper-scoped siblings tie structurally", () => {
+test("extractRenderedScore preserves the best legacy card when wrapper-scoped siblings are ambiguous and no modern summary exists", () => {
   const document = parseDocument(fixtures.sameWrapReviewCountTiebreakHtml);
   const result = renderedParser.extractRenderedScore(document, "B095JGJCC7");
 
@@ -82,6 +96,17 @@ test("extractRenderedScore prefers the highest-review legacy card when wrapper-s
   );
   assert.ok(result.verdict);
   assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level01.png");
+});
+
+test("extractRenderedScore falls back to the modern summary when wrapper-scoped legacy siblings are ambiguous", () => {
+  const document = parseDocument(fixtures.ambiguousWrapperWithModernHtml);
+  const result = renderedParser.extractRenderedScore(document, "B095JGJCC7");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.suffix, "%");
+  assert.equal(result.score.images.length, 1);
+  assert.ok(result.verdict);
+  assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/sakura_lv00.png");
 });
 
 test("extractRenderedScore waits when only unrelated legacy cards are rendered for the requested ASIN", () => {


### PR DESCRIPTION
## Summary
- switch Sakura Checker fetching to prefer itemsearch URLs by Base64-encoding the ASIN, while keeping the user-facing "Open Sakura Checker" link pointed at the detail page
- add parser support for itemsearch result rows so we can render text-based /5 scores with verdict text
- preserve legacy /5 extraction when wrapper-scoped matches are ambiguous and no modern summary exists, avoiding the regression where extraction could get stuck in not_ready
- update the UI to support both image-based and text-based score rendering
- extend tests to cover itemsearch, detail-link behavior, and the restored legacy ambiguous-wrapper fallback

## Validation
- npm test
- npm run test:browser-compare
- npm run test:e2e-extension with SAKURA_E2E_ASIN=B085XYHX7Y
- npm run test:e2e-extension with SAKURA_E2E_ASIN=B091BGMKYS

## Notes
- version bumped from 2.0.2 to 2.1.0
- updated package is available at C:/Users/mrmon/.codex/worktrees/958c/amazon-display-sakurachecker/extension.zip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR要約

- **ItemsearchスコアリングをASIN変換で優先化** / Sakura Checkerのフェッチを itemsearch URLを優先する仕様に変更し、ASIN のBase64エンコードで取得効率を向上させた

- **テキストベースのスコアパース機能を追加** / itemsearch結果行から/5形式のテキストスコアと判定テキスト（危険度・サクラ度）を直接抽出できるようにした

- **曖昧なラッパーマッチング時に従来型フォールバックを復活** / モダンサマリーが存在しない場合に legacy スコア抽出をフォールバックさせ、not_ready でのハング回避を実現した

- **UI コンポーネントがテキスト・イメージ両対応に進化** / 従来のイメージベーススコアと新しいテキストベーススコアの両方をレンダリングできるようにした

- **バージョンを 2.0.2 から 2.1.0 にアップデート** / 新しい itemsearch スコアリング機能の正式リリースに対応した

<!-- end of auto-generated comment: release notes by coderabbit.ai -->