### PR TITLE
Refactor parser injection flow and bump to 2.1.1

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,7 +11,6 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 
   self.ApiClient.checkSakuraScore({
     asin: request.asin,
-    forceRefresh: Boolean(request.forceRefresh),
   })
     .then((result) => sendResponse(result))
     .catch((error) => {
@@ -19,7 +18,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
         ok: false,
         code: "network_error",
         message: error instanceof Error ? error.message : "Unexpected background error.",
-        sourceUrl: self.ApiClient.buildSourceUrl(request.asin),
+        sourceUrl: self.ApiClient.buildDetailUrl(request.asin),
       });
     });
 

--- a/background.js
+++ b/background.js
@@ -1,5 +1,4 @@
 importScripts(
-  "background/rendered-score-parser.js",
   "background/rendered-score-client.js",
   "background/api-client.js"
 );

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -15,10 +15,6 @@
   const CACHE_PREFIX = "score:";
   const MIN_REQUEST_INTERVAL_MS = 2000;
   const MAX_REQUEST_JITTER_MS = 250;
-  const inFlightRequests = new Map();
-  let nextAllowedRequestAt = 0;
-  let rateLimitChain = Promise.resolve();
-  let requestExecutionChain = Promise.resolve();
 
   function encodeItemSearchWord(value) {
     const normalizedValue = String(value || "");
@@ -108,107 +104,218 @@
   }
 
   function hasValidSuccessPayload(payload) {
-    return Boolean(
-      payload &&
-      payload.ok === true &&
-      hasValidScorePayload(payload.score)
-    );
+    return Boolean(payload && payload.ok === true && hasValidScorePayload(payload.score));
   }
 
-  function hasStorage() {
-    return (
-      typeof chrome !== "undefined" &&
-      chrome.storage &&
-      chrome.storage.local &&
-      typeof chrome.storage.local.get === "function"
-    );
-  }
-
-  function storageGet(key) {
-    if (!hasStorage()) {
-      return Promise.resolve(null);
+  function createStorageAdapter() {
+    function hasStorage() {
+      return (
+        typeof chrome !== "undefined" &&
+        chrome.storage &&
+        chrome.storage.local &&
+        typeof chrome.storage.local.get === "function"
+      );
     }
 
-    return new Promise((resolve) => {
-      chrome.storage.local.get([key], (result) => {
-        resolve(result[key] || null);
+    function get(key) {
+      if (!hasStorage()) {
+        return Promise.resolve(null);
+      }
+
+      return new Promise((resolve) => {
+        chrome.storage.local.get([key], (result) => {
+          resolve(result[key] || null);
+        });
       });
-    });
-  }
-
-  function storageSet(key, value) {
-    if (!hasStorage()) {
-      return Promise.resolve();
     }
 
-    return new Promise((resolve) => {
-      chrome.storage.local.set({ [key]: value }, () => resolve());
-    });
-  }
+    function set(key, value) {
+      if (!hasStorage()) {
+        return Promise.resolve();
+      }
 
-  async function readCache(asin) {
-    const cacheKey = `${CACHE_PREFIX}${asin}`;
-    const cachedValue = await storageGet(cacheKey);
-    if (!cachedValue) {
-      return null;
-    }
-
-    const fetchedAt = Date.parse(cachedValue.fetchedAt);
-    if (Number.isNaN(fetchedAt) || Date.now() - fetchedAt > CACHE_TTL_MS) {
-      return null;
-    }
-
-    if (!hasValidSuccessPayload(cachedValue)) {
-      return null;
+      return new Promise((resolve) => {
+        chrome.storage.local.set({ [key]: value }, () => resolve());
+      });
     }
 
     return {
-      ...cachedValue,
-      sourceUrl: buildDetailUrl(asin),
+      get,
+      set,
     };
   }
 
-  async function writeCache(asin, payload) {
-    const cacheKey = `${CACHE_PREFIX}${asin}`;
-    await storageSet(cacheKey, payload);
+  function createScoreCache({ storage, ttlMs, keyPrefix, buildDetailUrlImpl }) {
+    async function read(asin) {
+      const cacheKey = `${keyPrefix}${asin}`;
+      const cachedValue = await storage.get(cacheKey);
+      if (!cachedValue) {
+        return null;
+      }
+
+      const fetchedAt = Date.parse(cachedValue.fetchedAt);
+      if (Number.isNaN(fetchedAt) || Date.now() - fetchedAt > ttlMs) {
+        return null;
+      }
+
+      if (!hasValidSuccessPayload(cachedValue)) {
+        return null;
+      }
+
+      return {
+        ...cachedValue,
+        sourceUrl: buildDetailUrlImpl(asin),
+      };
+    }
+
+    async function write(asin, payload) {
+      const cacheKey = `${keyPrefix}${asin}`;
+      await storage.set(cacheKey, payload);
+    }
+
+    return {
+      read,
+      write,
+    };
   }
 
   function defaultWait(milliseconds) {
     return new Promise((resolve) => setTimeout(resolve, milliseconds));
   }
 
-  async function waitForRateLimit({
+  function createRequestCoordinator({
+    minRequestIntervalMs,
+    maxRequestJitterMs,
     waitImpl = defaultWait,
-    nowImpl = Date.now,
-    randomImpl = Math.random,
-  } = {}) {
-    const reservation = rateLimitChain.then(async () => {
-      const now = nowImpl();
-      const waitMs = Math.max(0, nextAllowedRequestAt - now);
-      if (waitMs > 0) {
-        await waitImpl(waitMs);
-      }
+  }) {
+    let nextAllowedRequestAt = 0;
+    let rateLimitChain = Promise.resolve();
+    let executionChain = Promise.resolve();
 
-      const randomValue = Math.min(1, Math.max(0, Number(randomImpl()) || 0));
-      const jitterMs = Math.floor(randomValue * MAX_REQUEST_JITTER_MS);
-      nextAllowedRequestAt = nowImpl() + MIN_REQUEST_INTERVAL_MS + jitterMs;
-    });
+    async function waitForTurn({
+      waitOverride = waitImpl,
+      nowImpl = Date.now,
+      randomImpl = Math.random,
+    } = {}) {
+      const reservation = rateLimitChain.then(async () => {
+        const now = nowImpl();
+        const waitMs = Math.max(0, nextAllowedRequestAt - now);
+        if (waitMs > 0) {
+          await waitOverride(waitMs);
+        }
 
-    rateLimitChain = reservation.catch(() => {});
-    return reservation;
+        const randomValue = Math.min(1, Math.max(0, Number(randomImpl()) || 0));
+        const jitterMs = Math.floor(randomValue * maxRequestJitterMs);
+        nextAllowedRequestAt = nowImpl() + minRequestIntervalMs + jitterMs;
+      });
+
+      rateLimitChain = reservation.catch(() => {});
+      return reservation;
+    }
+
+    function enqueue(task) {
+      const queuedTask = executionChain.then(task, task);
+      executionChain = queuedTask.catch(() => {});
+      return queuedTask;
+    }
+
+    function reset() {
+      nextAllowedRequestAt = 0;
+      rateLimitChain = Promise.resolve();
+      executionChain = Promise.resolve();
+    }
+
+    return {
+      enqueue,
+      reset,
+      waitForTurn,
+    };
   }
 
-  function enqueueRequest(task) {
-    const queuedTask = requestExecutionChain.then(task, task);
-    requestExecutionChain = queuedTask.catch(() => {});
-    return queuedTask;
-  }
+  const storageAdapter = createStorageAdapter();
+  const scoreCache = createScoreCache({
+    storage: storageAdapter,
+    ttlMs: CACHE_TTL_MS,
+    keyPrefix: CACHE_PREFIX,
+    buildDetailUrlImpl: buildDetailUrl,
+  });
+  const requestCoordinator = createRequestCoordinator({
+    minRequestIntervalMs: MIN_REQUEST_INTERVAL_MS,
+    maxRequestJitterMs: MAX_REQUEST_JITTER_MS,
+  });
+  const inFlightRequests = new Map();
 
   function resetForTests() {
     inFlightRequests.clear();
-    nextAllowedRequestAt = 0;
-    rateLimitChain = Promise.resolve();
-    requestExecutionChain = Promise.resolve();
+    requestCoordinator.reset();
+  }
+
+  function buildSuccessPayload(asin, renderedResult) {
+    return {
+      ok: true,
+      cached: false,
+      fetchedAt: new Date().toISOString(),
+      sourceUrl: buildDetailUrl(asin),
+      score: renderedResult.score,
+      verdict: normalizeVerdict(renderedResult.verdict),
+    };
+  }
+
+  function normalizeFetchFailure(asin, renderedResult) {
+    return createFailure(
+      renderedResult && renderedResult.code ? renderedResult.code : "parse_error",
+      renderedResult && renderedResult.message
+        ? renderedResult.message
+        : "Could not extract a rendered Sakura Checker score.",
+      buildDetailUrl(asin)
+    );
+  }
+
+  async function fetchFreshScore({
+    asin,
+    fetchRenderedScore,
+    nowImpl,
+    randomImpl,
+    waitImpl,
+  }) {
+    const requestUrl = buildSourceUrl(asin);
+    const sourceUrl = buildDetailUrl(asin);
+    let renderedResult = null;
+
+    await requestCoordinator.waitForTurn({
+      waitOverride: waitImpl,
+      nowImpl,
+      randomImpl,
+    });
+
+    try {
+      renderedResult = await fetchRenderedScore({
+        asin,
+        sourceUrl: requestUrl,
+      });
+    } catch (error) {
+      return createFailure(
+        "network_error",
+        error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
+        sourceUrl
+      );
+    }
+
+    if (!renderedResult || !renderedResult.ok) {
+      return normalizeFetchFailure(asin, renderedResult);
+    }
+
+    if (!hasValidSuccessPayload(renderedResult)) {
+      return createFailure(
+        "parse_error",
+        "The rendered Sakura Checker response did not include a usable score.",
+        sourceUrl
+      );
+    }
+
+    const payload = buildSuccessPayload(asin, renderedResult);
+    await scoreCache.write(asin, payload);
+    return payload;
   }
 
   async function checkSakuraScore({
@@ -219,7 +326,6 @@
     randomImpl,
     waitImpl,
   }) {
-    const requestUrl = buildSourceUrl(asin);
     const sourceUrl = buildDetailUrl(asin);
 
     if (!RenderedScoreClient && typeof fetchRenderedScoreImpl !== "function") {
@@ -231,7 +337,7 @@
     }
 
     if (!forceRefresh) {
-      const cachedValue = await readCache(asin);
+      const cachedValue = await scoreCache.read(asin);
       if (cachedValue) {
         return { ...cachedValue, cached: true };
       }
@@ -246,63 +352,21 @@
       return inFlightRequests.get(asin);
     }
 
-    const requestPromise = enqueueRequest(async () => {
-      let renderedResult = null;
-
-      await waitForRateLimit({
-        waitImpl,
-        nowImpl,
-        randomImpl,
-      });
-
-      try {
-        renderedResult = await fetchRenderedScore({
+    const requestPromise = requestCoordinator
+      .enqueue(() =>
+        fetchFreshScore({
           asin,
-          sourceUrl: requestUrl,
-        });
-      } catch (error) {
-        return createFailure(
-          "network_error",
-          error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
-          sourceUrl
-        );
-      }
-
-      if (!renderedResult || !renderedResult.ok) {
-        return createFailure(
-          renderedResult && renderedResult.code ? renderedResult.code : "parse_error",
-          renderedResult && renderedResult.message
-            ? renderedResult.message
-            : "Could not extract a rendered Sakura Checker score.",
-          sourceUrl
-        );
-      }
-
-      if (!hasValidSuccessPayload(renderedResult)) {
-        return createFailure(
-          "parse_error",
-          "The rendered Sakura Checker response did not include a usable score.",
-          sourceUrl
-        );
-      }
-
-      const payload = {
-        ok: true,
-        cached: false,
-        fetchedAt: new Date().toISOString(),
-        sourceUrl,
-        score: renderedResult.score,
-        verdict: normalizeVerdict(renderedResult.verdict),
-      };
-
-      await writeCache(asin, payload);
-
-      return payload;
-    }).finally(() => {
-      if (inFlightRequests.get(asin) === requestPromise) {
-        inFlightRequests.delete(asin);
-      }
-    });
+          fetchRenderedScore,
+          nowImpl,
+          randomImpl,
+          waitImpl,
+        })
+      )
+      .finally(() => {
+        if (inFlightRequests.get(asin) === requestPromise) {
+          inFlightRequests.delete(asin);
+        }
+      });
 
     inFlightRequests.set(asin, requestPromise);
     return requestPromise;
@@ -314,9 +378,9 @@
     checkSakuraScore,
     encodeItemSearchWord,
     __testing: {
-      readCache,
+      readCache: scoreCache.read,
       reset: resetForTests,
-      writeCache,
+      writeCache: scoreCache.write,
     },
   };
 });

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -309,13 +309,14 @@
   }
 
   return {
-    __resetForTests: resetForTests,
     buildDetailUrl,
     buildSourceUrl,
     checkSakuraScore,
-    createFailure,
     encodeItemSearchWord,
-    readCache,
-    writeCache,
+    __testing: {
+      readCache,
+      reset: resetForTests,
+      writeCache,
+    },
   };
 });

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -1,18 +1,13 @@
 (function (root, factory) {
-  const exportsObject = factory(
-    root.RenderedScoreParser,
-    typeof module !== "undefined" && module.exports
-      ? require("./rendered-score-parser.js")
-      : null
-  );
+  const exportsObject = factory();
   if (typeof module !== "undefined" && module.exports) {
     module.exports = exportsObject;
   }
   root.RenderedScoreClient = exportsObject;
-})(typeof self !== "undefined" ? self : globalThis, function (workerParser, nodeParser) {
-  const RenderedScoreParser = workerParser || nodeParser;
+})(typeof self !== "undefined" ? self : globalThis, function () {
   const DEFAULT_TIMEOUT_MS = 15000;
   const DEFAULT_POLL_INTERVAL_MS = 250;
+  const PARSER_SCRIPT_FILE = "background/rendered-score-parser.js";
 
   function delay(milliseconds) {
     return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -102,6 +97,38 @@
     });
   }
 
+  function injectParser(tabId) {
+    return new Promise((resolve, reject) => {
+      if (
+        typeof chrome === "undefined" ||
+        !chrome.scripting ||
+        typeof chrome.scripting.executeScript !== "function"
+      ) {
+        reject(new Error("chrome.scripting.executeScript is not available."));
+        return;
+      }
+
+      chrome.scripting.executeScript(
+        {
+          target: { tabId },
+          files: [PARSER_SCRIPT_FILE],
+        },
+        () => {
+          if (
+            typeof chrome !== "undefined" &&
+            chrome.runtime &&
+            chrome.runtime.lastError
+          ) {
+            reject(createChromeError("Failed to prepare the Sakura Checker parser."));
+            return;
+          }
+
+          resolve();
+        }
+      );
+    });
+  }
+
   function executeExtract(tabId, asin) {
     return new Promise((resolve, reject) => {
       if (
@@ -113,18 +140,25 @@
         return;
       }
 
-      if (
-        !RenderedScoreParser ||
-        typeof RenderedScoreParser.extractRenderedScore !== "function"
-      ) {
-        reject(new Error("RenderedScoreParser.extractRenderedScore is not available."));
-        return;
-      }
-
       chrome.scripting.executeScript(
         {
           target: { tabId },
-          func: RenderedScoreParser.extractRenderedScore,
+          func: (requestedAsin) => {
+            if (
+              typeof self === "undefined" ||
+              !self.RenderedScoreParser ||
+              typeof self.RenderedScoreParser.extractRenderedScore !== "function"
+            ) {
+              return {
+                ok: false,
+                code: "parse_error",
+                message: "RenderedScoreParser.extractRenderedScore is not available.",
+                retryable: false,
+              };
+            }
+
+            return self.RenderedScoreParser.extractRenderedScore(document, requestedAsin);
+          },
           args: asin ? [asin] : [],
         },
         (injectionResults) => {
@@ -265,6 +299,7 @@
       });
 
       await waitForTabComplete(tab.id, timeoutMs);
+      await injectParser(tab.id);
       return await pollExtractedScore(tab.id, {
         asin,
         timeoutMs,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -129,6 +129,26 @@
     });
   }
 
+  async function injectParserWithRetry(tabId, options = {}) {
+    const timeoutMs = Number(options.timeoutMs || DEFAULT_TIMEOUT_MS);
+    const pollIntervalMs = Number(options.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS);
+    const startedAt = Date.now();
+    let lastError = null;
+
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        await injectParser(tabId);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+
+      await delay(pollIntervalMs);
+    }
+
+    throw lastError || new Error("Timed out preparing the Sakura Checker parser.");
+  }
+
   function executeExtract(tabId, asin) {
     return new Promise((resolve, reject) => {
       if (
@@ -299,7 +319,10 @@
       });
 
       await waitForTabComplete(tab.id, timeoutMs);
-      await injectParser(tab.id);
+      await injectParserWithRetry(tab.id, {
+        timeoutMs,
+        pollIntervalMs,
+      });
       return await pollExtractedScore(tab.id, {
         asin,
         timeoutMs,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -278,14 +278,6 @@
   }
 
   return {
-    DEFAULT_POLL_INTERVAL_MS,
-    DEFAULT_TIMEOUT_MS,
-    executeExtract,
     fetchRenderedScore,
-    pollExtractedScore,
-    tabsCreate,
-    tabsGet,
-    tabsRemove,
-    waitForTabComplete,
   };
 });

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -5,7 +5,48 @@
   }
   root.RenderedScoreParser = exportsObject;
 })(typeof self !== "undefined" ? self : globalThis, function () {
-  function extractRenderedScore(rootNodeOrAsin, maybeRequestedAsin) {
+  function createFailure(code, message, retryable) {
+    return {
+      ok: false,
+      code,
+      message,
+      retryable,
+    };
+  }
+
+  function normalizeText(value) {
+    return String(value || "")
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function createTextVerdict(lines) {
+    const normalizedLines = Array.isArray(lines)
+      ? lines.map(normalizeText).filter(Boolean)
+      : [];
+    if (!normalizedLines.length) {
+      return null;
+    }
+
+    return {
+      kind: "text-verdict",
+      lines: normalizedLines,
+    };
+  }
+
+  function buildRequestedAsinPattern(requestedAsin) {
+    if (!requestedAsin) {
+      return null;
+    }
+
+    return new RegExp(
+      `(?:/dp/|/gp/product/|/search/|\\b)${requestedAsin}(?:[/?#&]|$)`,
+      "i"
+    );
+  }
+
+  function createContext(rootNodeOrAsin, maybeRequestedAsin) {
     const root =
       rootNodeOrAsin && typeof rootNodeOrAsin.querySelector === "function"
         ? rootNodeOrAsin
@@ -14,539 +55,558 @@
       root === rootNodeOrAsin ? maybeRequestedAsin : rootNodeOrAsin;
 
     if (!root || typeof root.querySelector !== "function") {
-      return {
-        ok: false,
-        code: "parse_error",
-        message: "A DOM root is required to extract the rendered Sakura Checker score.",
-        retryable: false,
-      };
+      return null;
     }
 
-    function normalizeText(value) {
-      return String(value || "")
-        .replace(/\u00a0/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
+    return {
+      requestedAsin,
+      requestedAsinPattern: buildRequestedAsinPattern(requestedAsin),
+      root,
+    };
+  }
+
+  function currentPathname(context) {
+    try {
+      if (context.root.location && context.root.location.pathname) {
+        return context.root.location.pathname;
+      }
+    } catch {
+      // Ignore DOM location access issues and fall back.
     }
 
-    function resolveUrl(value) {
-      if (!value) {
-        return value;
-      }
-
-      if (/^(?:data:|https?:|chrome-extension:)/i.test(value)) {
-        return value;
-      }
-
-      const baseUrl =
-        root.baseURI ||
-        ((root.location && root.location.href) || null) ||
-        (typeof location !== "undefined" ? location.href : null);
-
-      if (!baseUrl) {
-        return value;
-      }
-
-      try {
-        return new URL(value, baseUrl).toString();
-      } catch {
-        return value;
-      }
+    if (typeof location !== "undefined" && location.pathname) {
+      return location.pathname;
     }
 
-    function getImagePayload(image) {
-      if (!image) {
-        return null;
-      }
+    return "";
+  }
 
-      const src = resolveUrl(image.src || image.getAttribute("src") || "");
-      if (!src) {
-        return null;
+  function currentTitle(context) {
+    try {
+      if (typeof context.root.title === "string" && context.root.title) {
+        return context.root.title;
       }
-
-      return {
-        src,
-        alt: image.getAttribute("alt") || image.alt || "",
-      };
+    } catch {
+      // Ignore title access issues and fall back.
     }
 
-    function getRatingImages(ratingNodes) {
-      const imageGroups = Array.from(ratingNodes, (ratingNode) =>
-        Array.from(ratingNode.querySelectorAll("img"))
-          .map(getImagePayload)
-          .filter(Boolean)
-      ).filter((group) => group.length);
+    if (typeof document !== "undefined" && typeof document.title === "string") {
+      return document.title;
+    }
 
-      if (!imageGroups.length) {
-        return [];
-      }
+    return "";
+  }
 
-      const richestGroup = imageGroups.reduce((bestGroup, currentGroup) =>
-        currentGroup.length > bestGroup.length ? currentGroup : bestGroup
-      );
+  function resolveUrl(context, value) {
+    if (!value) {
+      return value;
+    }
 
-      if (richestGroup.length > 1) {
-        return richestGroup;
-      }
+    if (/^(?:data:|https?:|chrome-extension:)/i.test(value)) {
+      return value;
+    }
 
-      if (imageGroups.length > 1) {
-        return imageGroups.flat();
-      }
+    const baseUrl =
+      context.root.baseURI ||
+      ((context.root.location && context.root.location.href) || null) ||
+      (typeof location !== "undefined" ? location.href : null);
 
+    if (!baseUrl) {
+      return value;
+    }
+
+    try {
+      return new URL(value, baseUrl).toString();
+    } catch {
+      return value;
+    }
+  }
+
+  function getImagePayload(context, image) {
+    if (!image) {
+      return null;
+    }
+
+    const src = resolveUrl(context, image.src || image.getAttribute("src") || "");
+    if (!src) {
+      return null;
+    }
+
+    return {
+      src,
+      alt: image.getAttribute("alt") || image.alt || "",
+    };
+  }
+
+  function getRatingImages(context, ratingNodes) {
+    const imageGroups = Array.from(ratingNodes, (ratingNode) =>
+      Array.from(ratingNode.querySelectorAll("img"))
+        .map((image) => getImagePayload(context, image))
+        .filter(Boolean)
+    ).filter((group) => group.length);
+
+    if (!imageGroups.length) {
+      return [];
+    }
+
+    const richestGroup = imageGroups.reduce((bestGroup, currentGroup) =>
+      currentGroup.length > bestGroup.length ? currentGroup : bestGroup
+    );
+
+    if (richestGroup.length > 1) {
       return richestGroup;
     }
 
-    function getVerdictLines(node) {
-      if (!node) {
-        return [];
-      }
-
-      return node.innerHTML
-        .split(/<br\s*\/?>/i)
-        .map((segment) => normalizeText(segment.replace(/<[^>]+>/g, " ")))
-        .filter(Boolean);
+    if (imageGroups.length > 1) {
+      return imageGroups.flat();
     }
 
-    function createTextVerdict(lines) {
-      const normalizedLines = Array.isArray(lines)
-        ? lines.map(normalizeText).filter(Boolean)
-        : [];
-      if (!normalizedLines.length) {
-        return null;
-      }
+    return richestGroup;
+  }
 
-      return {
-        kind: "text-verdict",
-        lines: normalizedLines,
-      };
+  function getVerdictLines(node) {
+    if (!node) {
+      return [];
     }
 
-    function buildRequestedAsinPattern() {
-      if (!requestedAsin) {
-        return null;
-      }
+    return node.innerHTML
+      .split(/<br\s*\/?>/i)
+      .map((segment) => normalizeText(segment.replace(/<[^>]+>/g, " ")))
+      .filter(Boolean);
+  }
 
-      return new RegExp(
-        `(?:/dp/|/gp/product/|/search/|\\b)${requestedAsin}(?:[/?#&]|$)`,
-        "i"
-      );
+  function anchorMatchesRequestedAsin(context, anchor) {
+    if (!context.requestedAsinPattern || !anchor) {
+      return false;
     }
 
-    const requestedAsinPattern = buildRequestedAsinPattern();
+    return context.requestedAsinPattern.test(
+      String(anchor.getAttribute("href") || anchor.href || "")
+    );
+  }
 
-    function anchorMatchesRequestedAsin(anchor) {
-      if (!requestedAsinPattern || !anchor) {
+  function getDirectChildItemInfos(reviewWrap) {
+    if (!reviewWrap || !reviewWrap.children) {
+      return [];
+    }
+
+    return Array.from(reviewWrap.children).filter(
+      (child) =>
+        child &&
+        typeof child.matches === "function" &&
+        child.matches(".item-info")
+    );
+  }
+
+  function reviewWrapMatchesRequestedAsin(context, reviewWrap) {
+    if (!context.requestedAsinPattern || !reviewWrap) {
+      return false;
+    }
+
+    return Array.from(reviewWrap.querySelectorAll("a[href]")).some((anchor) =>
+      anchorMatchesRequestedAsin(context, anchor)
+    );
+  }
+
+  function hasExactRequestedAsinMatch(context, itemInfo) {
+    if (!context.requestedAsin) {
+      return false;
+    }
+
+    const ownAnchors = Array.from(itemInfo.querySelectorAll("a[href]"));
+    if (ownAnchors.some((anchor) => anchorMatchesRequestedAsin(context, anchor))) {
+      return true;
+    }
+
+    return String(itemInfo.outerHTML || "").includes(context.requestedAsin);
+  }
+
+  function hasPendingRequestedLegacyCard(context) {
+    if (!context.requestedAsinPattern) {
+      return false;
+    }
+
+    return Array.from(context.root.querySelectorAll(".item-review-wrap")).some((reviewWrap) => {
+      const anchors = Array.from(reviewWrap.querySelectorAll("a[href]"));
+      if (!anchors.some((anchor) => anchorMatchesRequestedAsin(context, anchor))) {
         return false;
       }
 
-      return requestedAsinPattern.test(
-        String(anchor.getAttribute("href") || anchor.href || "")
-      );
+      return Boolean(reviewWrap.querySelector(".loader, .loading")) ||
+        !reviewWrap.querySelector(".item-info");
+    });
+  }
+
+  function getLegacyCandidateData(context, itemInfo) {
+    const reviewCountText = normalizeText(
+      (itemInfo.querySelector(".item-num .boldtxt") || {}).textContent || ""
+    );
+    const reviewCount = Number(reviewCountText.replace(/[^\d]/g, "")) || 0;
+    const ratingNodes = itemInfo.querySelectorAll("p.item-rating");
+    const images = getRatingImages(context, ratingNodes);
+    if (!images.length) {
+      return null;
     }
 
-    function getDirectChildItemInfos(reviewWrap) {
-      if (!reviewWrap || !reviewWrap.children) {
-        return [];
-      }
+    const verdictRoot = itemInfo.querySelector(".item-review-level");
+    const verdictImage = getImagePayload(
+      context,
+      verdictRoot && verdictRoot.querySelector(".item-rv-lv img, .item-rv-lv-image img, img")
+    );
+    const verdictLines = getVerdictLines(
+      verdictRoot && verdictRoot.querySelector(".item-rv-score")
+    );
 
-      return Array.from(reviewWrap.children).filter(
-        (child) =>
-          child &&
-          typeof child.matches === "function" &&
-          child.matches(".item-info")
-      );
+    let score = images.length * 10;
+    if (verdictRoot) {
+      score += 100;
+    }
+    if (itemInfo.querySelector(".item-rv-score")) {
+      score += 50;
+    }
+    if (itemInfo.querySelector(".button-mini, .button.button-mini, .item-review-level a")) {
+      score += 25;
+    }
+    if (verdictImage) {
+      score += 15;
+    }
+    if (normalizeText(itemInfo.textContent).includes("/5")) {
+      score += 5;
     }
 
-    function reviewWrapMatchesRequestedAsin(reviewWrap) {
-      if (!requestedAsinPattern || !reviewWrap) {
+    return {
+      reviewCount,
+      score,
+      scorePayload: {
+        kind: "visual-image",
+        images,
+        suffix: "/5",
+      },
+      verdict:
+        verdictImage && verdictLines.length
+          ? {
+              kind: "visual-verdict",
+              image: verdictImage,
+              lines: verdictLines,
+            }
+          : null,
+    };
+  }
+
+  function collectLegacyCandidates(context, allowAmbiguousMatches) {
+    const seen = new Set();
+    const candidates = Array.from(
+      context.root.querySelectorAll(".item-review-wrap .item-info, .item-info")
+    ).filter((itemInfo) => {
+      if (seen.has(itemInfo)) {
         return false;
       }
+      seen.add(itemInfo);
+      return true;
+    });
 
-      return Array.from(reviewWrap.querySelectorAll("a[href]")).some(anchorMatchesRequestedAsin);
-    }
+    let matchingCandidates = candidates;
+    let scopedCandidates = candidates;
 
-    function hasExactRequestedAsinMatch(itemInfo) {
-      if (!requestedAsin) {
-        return false;
-      }
-
-      const ownAnchors = Array.from(itemInfo.querySelectorAll("a[href]"));
-      if (ownAnchors.some(anchorMatchesRequestedAsin)) {
-        return true;
-      }
-
-      return String(itemInfo.outerHTML || "").includes(requestedAsin);
-    }
-
-    function hasPendingRequestedLegacyCard() {
-      if (!requestedAsinPattern) {
-        return false;
-      }
-
-      return Array.from(root.querySelectorAll(".item-review-wrap")).some((reviewWrap) => {
-        const anchors = Array.from(reviewWrap.querySelectorAll("a[href]"));
-        if (!anchors.some(anchorMatchesRequestedAsin)) {
-          return false;
-        }
-
-        return Boolean(reviewWrap.querySelector(".loader, .loading")) ||
-          !reviewWrap.querySelector(".item-info");
-      });
-    }
-
-    function getLegacyCandidateData(itemInfo) {
-      const reviewCountText = normalizeText(
-        (itemInfo.querySelector(".item-num .boldtxt") || {}).textContent || ""
-      );
-      const reviewCount = Number(reviewCountText.replace(/[^\d]/g, "")) || 0;
-      const ratingNodes = itemInfo.querySelectorAll("p.item-rating");
-      const images = getRatingImages(ratingNodes);
-      if (!images.length) {
-        return null;
-      }
-
-      const verdictRoot = itemInfo.querySelector(".item-review-level");
-      const verdictImage = getImagePayload(
-        verdictRoot && verdictRoot.querySelector(".item-rv-lv img, .item-rv-lv-image img, img")
-      );
-      const verdictLines = getVerdictLines(
-        verdictRoot && verdictRoot.querySelector(".item-rv-score")
+    if (context.requestedAsin) {
+      const matchingWraps = Array.from(context.root.querySelectorAll(".item-review-wrap")).filter(
+        (reviewWrap) => reviewWrapMatchesRequestedAsin(context, reviewWrap)
       );
 
-      let score = images.length * 10;
-      if (verdictRoot) {
-        score += 100;
-      }
-      if (itemInfo.querySelector(".item-rv-score")) {
-        score += 50;
-      }
-      if (itemInfo.querySelector(".button-mini, .button.button-mini, .item-review-level a")) {
-        score += 25;
-      }
-      if (verdictImage) {
-        score += 15;
-      }
-      if (normalizeText(itemInfo.textContent).includes("/5")) {
-        score += 5;
-      }
+      const exactCandidates = matchingWraps.flatMap((reviewWrap) =>
+        getDirectChildItemInfos(reviewWrap).filter((itemInfo) =>
+          hasExactRequestedAsinMatch(context, itemInfo)
+        )
+      );
 
-      return {
-        score,
-        reviewCount,
-        scorePayload: {
-          kind: "visual-image",
-          images,
-          suffix: "/5",
-        },
-        verdict:
-          verdictImage && verdictLines.length
-            ? {
-                kind: "visual-verdict",
-                image: verdictImage,
-                lines: verdictLines,
-              }
-            : null,
-      };
-    }
-
-    function extractLegacyScore(options = {}) {
-      const allowAmbiguousMatches = Boolean(options.allowAmbiguousMatches);
-      const seen = new Set();
-      const candidates = Array.from(
-        root.querySelectorAll(".item-review-wrap .item-info, .item-info")
-      ).filter((itemInfo) => {
-        if (seen.has(itemInfo)) {
-          return false;
-        }
-        seen.add(itemInfo);
-        return true;
-      });
-
-      let scopedCandidates = candidates;
-      let matchingCandidates = candidates;
-
-      if (requestedAsin) {
-        const matchingWraps = Array.from(root.querySelectorAll(".item-review-wrap")).filter(
-          reviewWrapMatchesRequestedAsin
+      if (exactCandidates.length) {
+        matchingCandidates = exactCandidates;
+        scopedCandidates = exactCandidates;
+      } else {
+        const ambiguousWrapCandidates = matchingWraps.flatMap((reviewWrap) =>
+          getDirectChildItemInfos(reviewWrap)
         );
+        const singleCardWrapCandidates = matchingWraps
+          .map((reviewWrap) => getDirectChildItemInfos(reviewWrap))
+          .filter((itemInfos) => itemInfos.length === 1)
+          .map((itemInfos) => itemInfos[0]);
 
-        const exactCandidates = matchingWraps.flatMap((reviewWrap) =>
-          getDirectChildItemInfos(reviewWrap).filter(hasExactRequestedAsinMatch)
-        );
-
-        if (exactCandidates.length) {
-          matchingCandidates = exactCandidates;
-          scopedCandidates = exactCandidates;
+        if (singleCardWrapCandidates.length) {
+          matchingCandidates = singleCardWrapCandidates;
+          scopedCandidates = singleCardWrapCandidates;
+        } else if (allowAmbiguousMatches && ambiguousWrapCandidates.length) {
+          matchingCandidates = ambiguousWrapCandidates;
+          scopedCandidates = ambiguousWrapCandidates;
         } else {
-          const ambiguousWrapCandidates = matchingWraps.flatMap((reviewWrap) =>
-            getDirectChildItemInfos(reviewWrap)
-          );
-          const singleCardWrapCandidates = matchingWraps
-            .map((reviewWrap) => getDirectChildItemInfos(reviewWrap))
-            .filter((itemInfos) => itemInfos.length === 1)
-            .map((itemInfos) => itemInfos[0]);
-
-          if (singleCardWrapCandidates.length) {
-            matchingCandidates = singleCardWrapCandidates;
-            scopedCandidates = singleCardWrapCandidates;
-          } else if (allowAmbiguousMatches && ambiguousWrapCandidates.length) {
-            matchingCandidates = ambiguousWrapCandidates;
-            scopedCandidates = ambiguousWrapCandidates;
-          } else {
-            matchingCandidates = [];
-            scopedCandidates = [];
-          }
+          matchingCandidates = [];
+          scopedCandidates = [];
         }
       }
+    }
 
-      const bestCandidate = scopedCandidates
-        .map(getLegacyCandidateData)
+    return {
+      candidates,
+      matchingCandidates,
+      scopedCandidates,
+    };
+  }
+
+  function pickBestLegacyCandidate(candidateDataList) {
+    return candidateDataList.reduce((best, candidate) => {
+      if (!best) {
+        return candidate;
+      }
+
+      if (candidate.score !== best.score) {
+        return candidate.score > best.score ? candidate : best;
+      }
+
+      return candidate.reviewCount > best.reviewCount ? candidate : best;
+    }, null);
+  }
+
+  function extractLegacyScore(context, options = {}) {
+    const allowAmbiguousMatches = Boolean(options.allowAmbiguousMatches);
+    const { candidates, matchingCandidates, scopedCandidates } = collectLegacyCandidates(
+      context,
+      allowAmbiguousMatches
+    );
+    const bestCandidate = pickBestLegacyCandidate(
+      scopedCandidates
+        .map((itemInfo) => getLegacyCandidateData(context, itemInfo))
         .filter(Boolean)
-        .reduce((best, candidate) => {
-          if (!best) {
-            return candidate;
-          }
+    );
 
-          if (candidate.score !== best.score) {
-            return candidate.score > best.score ? candidate : best;
-          }
-
-          return candidate.reviewCount > best.reviewCount ? candidate : best;
-        }, null);
-
-      if (!bestCandidate) {
-        if (requestedAsin && candidates.length && !matchingCandidates.length && hasPendingRequestedLegacyCard()) {
-          return {
-            ok: false,
-            code: "not_ready",
-            message: "Rendered Sakura Checker product card is not available yet.",
-            retryable: true,
-          };
-        }
-
-        return null;
-      }
-
-      return {
-        ok: true,
-        score: bestCandidate.scorePayload,
-        verdict: bestCandidate.verdict,
-      };
-    }
-
-    function extractItemSearchScore() {
-      const candidates = Array.from(root.querySelectorAll('[name="searchitem"]'));
-      if (!candidates.length) {
-        return null;
-      }
-
-      const matchingCandidate = candidates.find((candidate) => {
-        if (!requestedAsinPattern) {
-          return true;
-        }
-
-        return Array.from(candidate.querySelectorAll("a[href]")).some(anchorMatchesRequestedAsin);
-      });
-
-      if (!matchingCandidate) {
-        return null;
-      }
-
-      const scoreNode = matchingCandidate.querySelector(".item-info .item-rating, .item-rating");
-      const scoreText = normalizeText((scoreNode || {}).textContent || "");
-      const scoreMatch = scoreText.match(/([0-9]+(?:\.[0-9]+)?)\s*\/\s*5/i);
-      if (!scoreMatch) {
-        return null;
-      }
-
-      const sakuraPercentText = normalizeText(
-        (
-          matchingCandidate.querySelector(".item-info .item-sakura .is-size-7, .item-sakura .is-size-7") ||
-          {}
-        ).textContent || ""
-      );
-      const levelText = normalizeText(
-        (matchingCandidate.querySelector(".item-info .item-lv, .item-lv") || {}).textContent || ""
-      );
-
-      const verdictLines = [];
-      if (levelText) {
-        verdictLines.push(levelText);
-      }
-      if (sakuraPercentText) {
-        verdictLines.push(`サクラ度 ${sakuraPercentText}`);
-      }
-
-      return {
-        ok: true,
-        score: {
-          kind: "text",
-          value: scoreMatch[1],
-          suffix: "/5",
-        },
-        verdict: createTextVerdict(verdictLines),
-      };
-    }
-
-    function extractModernScore() {
-      const alertRoot = root.querySelector(".sakura-alert");
-      const scoreRoot = alertRoot && alertRoot.querySelector(".sakura-num");
-      if (!scoreRoot) {
-        return null;
-      }
-
-      const percentRoot = scoreRoot.querySelector(".sakura-num-per");
-      const images = Array.from(scoreRoot.querySelectorAll("img"))
-        .filter((image) => !percentRoot || !percentRoot.contains(image))
-        .map(getImagePayload)
-        .filter(Boolean);
-
-      if (!images.length) {
-        return null;
-      }
-
-      const verdictImage = getImagePayload(root.querySelector(".sakura-rating img"));
-      const verdictLine = normalizeText(
-        (root.querySelector(".sakura-msg") || {}).textContent || ""
-      );
-
-      return {
-        ok: true,
-        score: {
-          kind: "visual-image",
-          images,
-          suffix: "%",
-        },
-        verdict:
-          verdictImage && verdictLine
-            ? {
-                kind: "visual-verdict",
-                image: verdictImage,
-                lines: [verdictLine],
-              }
-            : null,
-      };
-    }
-
-    function currentPathname() {
-      try {
-        if (root.location && root.location.pathname) {
-          return root.location.pathname;
-        }
-      } catch {
-        // Ignore DOM location access issues and fall back.
-      }
-
-      if (typeof location !== "undefined" && location.pathname) {
-        return location.pathname;
-      }
-
-      return "";
-    }
-
-    function currentTitle() {
-      try {
-        if (typeof root.title === "string" && root.title) {
-          return root.title;
-        }
-      } catch {
-        // Ignore title access issues and fall back.
-      }
-
-      if (typeof document !== "undefined" && typeof document.title === "string") {
-        return document.title;
-      }
-
-      return "";
-    }
-
-    function detectBlockedPage() {
-      const pathname = currentPathname();
-      if (/\/error\/(?:accessdenied|forbidden|blocked|captcha)\//i.test(pathname)) {
-        return {
-          ok: false,
-          code: "blocked",
-          message: "Sakura Checker temporarily blocked the request.",
-          retryable: false,
-        };
-      }
-
-      const title = normalizeText(currentTitle()).toLowerCase();
-      const bodyText = normalizeText((root.body && root.body.textContent) || root.textContent || "");
-      const bodyTextLower = bodyText.toLowerCase();
-      const blockedPatterns = [
-        /too many requests/i,
-        /access denied/i,
-        /forbidden/i,
-        /captcha/i,
-        /recaptcha/i,
-        /アクセスが集中/i,
-        /アクセス制限/i,
-        /しばらく待/i,
-        /botではないこと/i,
-      ];
-
-      if (blockedPatterns.some((pattern) => pattern.test(title) || pattern.test(bodyTextLower) || pattern.test(bodyText))) {
-        return {
-          ok: false,
-          code: "blocked",
-          message: "Sakura Checker temporarily blocked the request.",
-          retryable: false,
-        };
+    if (!bestCandidate) {
+      if (
+        context.requestedAsin &&
+        candidates.length &&
+        !matchingCandidates.length &&
+        hasPendingRequestedLegacyCard(context)
+      ) {
+        return createFailure(
+          "not_ready",
+          "Rendered Sakura Checker product card is not available yet.",
+          true
+        );
       }
 
       return null;
     }
 
-    const blocked = detectBlockedPage();
+    return {
+      ok: true,
+      score: bestCandidate.scorePayload,
+      verdict: bestCandidate.verdict,
+    };
+  }
+
+  function extractItemSearchScore(context) {
+    const candidates = Array.from(context.root.querySelectorAll('[name="searchitem"]'));
+    if (!candidates.length) {
+      return null;
+    }
+
+    const matchingCandidate = candidates.find((candidate) => {
+      if (!context.requestedAsinPattern) {
+        return true;
+      }
+
+      return Array.from(candidate.querySelectorAll("a[href]")).some((anchor) =>
+        anchorMatchesRequestedAsin(context, anchor)
+      );
+    });
+
+    if (!matchingCandidate) {
+      return null;
+    }
+
+    const scoreNode = matchingCandidate.querySelector(".item-info .item-rating, .item-rating");
+    const scoreText = normalizeText((scoreNode || {}).textContent || "");
+    const scoreMatch = scoreText.match(/([0-9]+(?:\.[0-9]+)?)\s*\/\s*5/i);
+    if (!scoreMatch) {
+      return null;
+    }
+
+    const sakuraPercentText = normalizeText(
+      (
+        matchingCandidate.querySelector(".item-info .item-sakura .is-size-7, .item-sakura .is-size-7") ||
+        {}
+      ).textContent || ""
+    );
+    const levelText = normalizeText(
+      (matchingCandidate.querySelector(".item-info .item-lv, .item-lv") || {}).textContent || ""
+    );
+
+    const verdictLines = [];
+    if (levelText) {
+      verdictLines.push(levelText);
+    }
+    if (sakuraPercentText) {
+      verdictLines.push(`サクラ度 ${sakuraPercentText}`);
+    }
+
+    return {
+      ok: true,
+      score: {
+        kind: "text",
+        value: scoreMatch[1],
+        suffix: "/5",
+      },
+      verdict: createTextVerdict(verdictLines),
+    };
+  }
+
+  function extractModernScore(context) {
+    const alertRoot = context.root.querySelector(".sakura-alert");
+    const scoreRoot = alertRoot && alertRoot.querySelector(".sakura-num");
+    if (!scoreRoot) {
+      return null;
+    }
+
+    const percentRoot = scoreRoot.querySelector(".sakura-num-per");
+    const images = Array.from(scoreRoot.querySelectorAll("img"))
+      .filter((image) => !percentRoot || !percentRoot.contains(image))
+      .map((image) => getImagePayload(context, image))
+      .filter(Boolean);
+
+    if (!images.length) {
+      return null;
+    }
+
+    const verdictImage = getImagePayload(context, context.root.querySelector(".sakura-rating img"));
+    const verdictLine = normalizeText(
+      (context.root.querySelector(".sakura-msg") || {}).textContent || ""
+    );
+
+    return {
+      ok: true,
+      score: {
+        kind: "visual-image",
+        images,
+        suffix: "%",
+      },
+      verdict:
+        verdictImage && verdictLine
+          ? {
+              kind: "visual-verdict",
+              image: verdictImage,
+              lines: [verdictLine],
+            }
+          : null,
+    };
+  }
+
+  function detectBlockedPage(context) {
+    const pathname = currentPathname(context);
+    if (/\/error\/(?:accessdenied|forbidden|blocked|captcha)\//i.test(pathname)) {
+      return createFailure(
+        "blocked",
+        "Sakura Checker temporarily blocked the request.",
+        false
+      );
+    }
+
+    const title = normalizeText(currentTitle(context)).toLowerCase();
+    const bodyText = normalizeText(
+      (context.root.body && context.root.body.textContent) || context.root.textContent || ""
+    );
+    const bodyTextLower = bodyText.toLowerCase();
+    const blockedPatterns = [
+      /too many requests/i,
+      /access denied/i,
+      /forbidden/i,
+      /captcha/i,
+      /recaptcha/i,
+      /アクセスが集中/i,
+      /アクセス制限/i,
+      /しばらく待/i,
+      /botではないこと/i,
+    ];
+
+    if (
+      blockedPatterns.some(
+        (pattern) =>
+          pattern.test(title) || pattern.test(bodyTextLower) || pattern.test(bodyText)
+      )
+    ) {
+      return createFailure(
+        "blocked",
+        "Sakura Checker temporarily blocked the request.",
+        false
+      );
+    }
+
+    return null;
+  }
+
+  function detectMissingProduct(context) {
+    if (/\/error\/notfound\//.test(currentPathname(context))) {
+      return createFailure(
+        "not_found",
+        "The product was not found on Sakura Checker.",
+        false
+      );
+    }
+
+    return null;
+  }
+
+  function buildFallbackResult(context) {
+    const hasLoadingSignals = Boolean(
+      context.root.querySelector(".loader, .loading, .item-review-wrap, .sakuraBlock, #pagetop")
+    );
+
+    return createFailure(
+      hasLoadingSignals ? "not_ready" : "parse_error",
+      hasLoadingSignals
+        ? "Rendered Sakura Checker score is not available yet."
+        : "Could not locate a rendered Sakura Checker score.",
+      hasLoadingSignals
+    );
+  }
+
+  function extractRenderedScore(rootNodeOrAsin, maybeRequestedAsin) {
+    const context = createContext(rootNodeOrAsin, maybeRequestedAsin);
+    if (!context) {
+      return createFailure(
+        "parse_error",
+        "A DOM root is required to extract the rendered Sakura Checker score.",
+        false
+      );
+    }
+
+    const blocked = detectBlockedPage(context);
     if (blocked) {
       return blocked;
     }
 
-    if (/\/error\/notfound\//.test(currentPathname())) {
-      return {
-        ok: false,
-        code: "not_found",
-        message: "The product was not found on Sakura Checker.",
-        retryable: false,
-      };
+    const missingProduct = detectMissingProduct(context);
+    if (missingProduct) {
+      return missingProduct;
     }
 
-    const itemSearch = extractItemSearchScore();
+    const itemSearch = extractItemSearchScore(context);
     if (itemSearch) {
       return itemSearch;
     }
 
-    const legacy = extractLegacyScore();
-    if (legacy && legacy.ok) {
-      return legacy;
-    }
-    if (legacy && legacy.code === "not_ready") {
+    const legacy = extractLegacyScore(context);
+    if (legacy && (legacy.ok || legacy.code === "not_ready")) {
       return legacy;
     }
 
-    const modern = extractModernScore();
+    const modern = extractModernScore(context);
     if (modern) {
       return modern;
     }
 
-    const ambiguousLegacy = extractLegacyScore({ allowAmbiguousMatches: true });
+    const ambiguousLegacy = extractLegacyScore(context, { allowAmbiguousMatches: true });
     if (ambiguousLegacy && ambiguousLegacy.ok) {
       return ambiguousLegacy;
     }
 
-    const hasLoadingSignals = Boolean(
-      root.querySelector(".loader, .loading, .item-review-wrap, .sakuraBlock, #pagetop")
-    );
-
-    return {
-      ok: false,
-      code: hasLoadingSignals ? "not_ready" : "parse_error",
-      message: hasLoadingSignals
-        ? "Rendered Sakura Checker score is not available yet."
-        : "Could not locate a rendered Sakura Checker score.",
-      retryable: hasLoadingSignals,
-    };
+    return buildFallbackResult(context);
   }
 
   return {

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -592,7 +592,7 @@
     }
 
     const legacy = extractLegacyScore(context);
-    if (legacy && (legacy.ok || legacy.code === "not_ready")) {
+    if (legacy && legacy.ok) {
       return legacy;
     }
 
@@ -604,6 +604,10 @@
     const ambiguousLegacy = extractLegacyScore(context, { allowAmbiguousMatches: true });
     if (ambiguousLegacy && ambiguousLegacy.ok) {
       return ambiguousLegacy;
+    }
+
+    if (legacy && legacy.code === "not_ready") {
+      return legacy;
     }
 
     return buildFallbackResult(context);

--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -1,13 +1,12 @@
 (function () {
-  const PRODUCT_PATH_PATTERN = /\/(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})(?:[/?#]|$)/i;
+  const asinUtils = window.AsinUtils;
 
-  function extractAsinFromPath(path) {
-    const match = String(path || "").match(PRODUCT_PATH_PATTERN);
-    return match ? match[1].toUpperCase() : null;
+  if (!asinUtils) {
+    throw new Error("AsinUtils is not available.");
   }
 
   function extractProductASIN() {
-    const pathAsin = extractAsinFromPath(window.location.pathname);
+    const pathAsin = asinUtils.extractAsinFromPath(window.location.pathname);
     if (pathAsin) {
       return pathAsin;
     }
@@ -15,7 +14,7 @@
     const canonical = document.querySelector('link[rel="canonical"]');
     const canonicalHref = canonical && canonical.getAttribute("href");
     if (canonicalHref) {
-      const canonicalAsin = extractAsinFromPath(canonicalHref);
+      const canonicalAsin = asinUtils.extractAsinFromUrl(canonicalHref);
       if (canonicalAsin) {
         return canonicalAsin;
       }

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -3,6 +3,7 @@
     constructor() {
       this.currentAsin = null;
       this.inFlight = false;
+      this.pendingRefresh = false;
     }
 
     init() {
@@ -10,29 +11,37 @@
       this.observePageChanges();
     }
 
+    getCurrentPageAsin() {
+      if (!window.AsinExtractor || !window.AsinExtractor.isProductPage()) {
+        return null;
+      }
+
+      return window.AsinExtractor.extractProductASIN();
+    }
+
     async refreshForCurrentPage() {
       if (!window.AsinExtractor || !window.UiDisplay) {
         return;
       }
 
-      if (!window.AsinExtractor.isProductPage()) {
+      const asin = this.getCurrentPageAsin();
+      if (!asin) {
         window.UiDisplay.remove();
         this.currentAsin = null;
+        this.pendingRefresh = false;
         return;
       }
 
-      const asin = window.AsinExtractor.extractProductASIN();
-      if (!asin || this.inFlight) {
-        if (!asin) {
-          window.UiDisplay.remove();
-          this.currentAsin = null;
-        }
+      if (this.inFlight) {
+        this.pendingRefresh = true;
         return;
       }
 
       this.currentAsin = asin;
       this.inFlight = true;
+      this.pendingRefresh = false;
       window.UiDisplay.renderLoading(`https://sakura-checker.jp/search/${asin}/`);
+      let latestAsin = asin;
 
       try {
         const response = await chrome.runtime.sendMessage({
@@ -40,7 +49,8 @@
           asin,
         });
 
-        if (asin !== this.currentAsin) {
+        latestAsin = this.getCurrentPageAsin();
+        if (latestAsin !== asin) {
           return;
         }
 
@@ -50,6 +60,11 @@
           window.UiDisplay.renderError(response);
         }
       } catch (error) {
+        latestAsin = this.getCurrentPageAsin();
+        if (latestAsin !== asin) {
+          return;
+        }
+
         window.UiDisplay.renderError(
           {
             ok: false,
@@ -63,6 +78,13 @@
         );
       } finally {
         this.inFlight = false;
+        const shouldRetry =
+          this.pendingRefresh &&
+          (latestAsin !== asin || !document.getElementById("sakura-checker-result"));
+        this.pendingRefresh = false;
+        if (shouldRetry) {
+          this.refreshForCurrentPage();
+        }
       }
     }
 
@@ -71,7 +93,6 @@
       const observer = new MutationObserver(() => {
         if (window.location.href !== previousUrl) {
           previousUrl = window.location.href;
-          this.currentAsin = null;
           this.refreshForCurrentPage();
           return;
         }

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -6,11 +6,11 @@
     }
 
     init() {
-      this.refreshForCurrentPage(false);
+      this.refreshForCurrentPage();
       this.observePageChanges();
     }
 
-    async refreshForCurrentPage(forceRefresh) {
+    async refreshForCurrentPage() {
       if (!window.AsinExtractor || !window.UiDisplay) {
         return;
       }
@@ -38,7 +38,6 @@
         const response = await chrome.runtime.sendMessage({
           action: "checkSakuraScore",
           asin,
-          forceRefresh: Boolean(forceRefresh),
         });
 
         if (asin !== this.currentAsin) {
@@ -73,12 +72,12 @@
         if (window.location.href !== previousUrl) {
           previousUrl = window.location.href;
           this.currentAsin = null;
-          this.refreshForCurrentPage(false);
+          this.refreshForCurrentPage();
           return;
         }
 
         if (this.currentAsin && !document.getElementById("sakura-checker-result")) {
-          this.refreshForCurrentPage(false);
+          this.refreshForCurrentPage();
         }
       });
 

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
         "https://www.amazon.co.jp/*"
       ],
       "js": [
+        "shared/asin-utils.js",
         "content/asin-extractor.js",
         "content/ui-display.js",
         "content/sakura-checker.js",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
-    "test": "node --test tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",
+    "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",
     "test:live": "node --test --test-concurrency=1 tests/integration.test.js",
     "test:e2e-extension": "node scripts/run-extension-e2e.js",
     "test:browser-compare": "node scripts/run-browser-compare.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/scripts/create-extension-zip.js
+++ b/scripts/create-extension-zip.js
@@ -17,6 +17,7 @@ const entries = [
   { type: "directory", relativePath: "background" },
   { type: "directory", relativePath: "content" },
   { type: "directory", relativePath: "icons" },
+  { type: "directory", relativePath: "shared" },
 ];
 
 function normalizeArchivePath(relativePath) {

--- a/scripts/run-extension-e2e.js
+++ b/scripts/run-extension-e2e.js
@@ -4,20 +4,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { chromium } = require("playwright");
-
-function extractAsinFromUrl(urlValue) {
-  if (!urlValue) {
-    return null;
-  }
-
-  try {
-    const parsed = new URL(urlValue);
-    const match = parsed.pathname.match(/\/(?:dp|gp\/product)\/([A-Z0-9]{10})/i);
-    return match ? match[1].toUpperCase() : null;
-  } catch {
-    return null;
-  }
-}
+const { extractAsinFromUrl } = require("../shared/asin-utils.js");
 
 function resolveAsin() {
   const explicitAsin = process.env.SAKURA_E2E_ASIN;
@@ -48,10 +35,6 @@ const SUCCESS_SCREENSHOT_PATH = path.join(OUTPUT_DIR, `extension-e2e-${DEFAULT_A
 const SETTLE_TIMEOUT_MS = Number(process.env.SAKURA_E2E_TIMEOUT_MS || 45000);
 const EXPECTED_SUFFIX = process.env.SAKURA_E2E_EXPECT_SUFFIX || "/5";
 const HEADLESS = process.env.PW_EXTENSION_HEADLESS !== "0";
-
-function encodeItemSearchWord(value) {
-  return Buffer.from(String(value || ""), "utf8").toString("base64");
-}
 
 function isSupportedSuffix(value) {
   return value === "/5" || value === "%";

--- a/shared/asin-utils.js
+++ b/shared/asin-utils.js
@@ -1,0 +1,32 @@
+(function (root, factory) {
+  const exportsObject = factory();
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = exportsObject;
+  }
+  root.AsinUtils = exportsObject;
+})(typeof self !== "undefined" ? self : globalThis, function () {
+  const PRODUCT_PATH_PATTERN = /\/(?:dp|gp\/product|gp\/aw\/d)\/([A-Z0-9]{10})(?:[/?#]|$)/i;
+
+  function extractAsinFromPath(path) {
+    const match = String(path || "").match(PRODUCT_PATH_PATTERN);
+    return match ? match[1].toUpperCase() : null;
+  }
+
+  function extractAsinFromUrl(urlValue) {
+    if (!urlValue) {
+      return null;
+    }
+
+    try {
+      const parsed = new URL(urlValue, "https://www.amazon.co.jp");
+      return extractAsinFromPath(parsed.pathname);
+    } catch {
+      return extractAsinFromPath(urlValue);
+    }
+  }
+
+  return {
+    extractAsinFromPath,
+    extractAsinFromUrl,
+  };
+});

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -34,7 +34,7 @@ function installChromeStorageStub() {
 }
 
 test("buildSourceUrl creates the Sakura Checker search URL", () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   assert.equal(
     apiClient.buildSourceUrl("B08N5WRWNW"),
     "https://sakura-checker.jp/itemsearch/?word=QjA4TjVXUldOVw=="
@@ -42,7 +42,7 @@ test("buildSourceUrl creates the Sakura Checker search URL", () => {
 });
 
 test("buildDetailUrl creates the Sakura Checker detail URL", () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   assert.equal(
     apiClient.buildDetailUrl("B08N5WRWNW"),
     "https://sakura-checker.jp/search/B08N5WRWNW/"
@@ -54,7 +54,7 @@ test("encodeItemSearchWord base64-encodes the ASIN", () => {
 });
 
 test("checkSakuraScore caches successful rendered responses", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const cleanup = installChromeStorageStub();
   let fetchRenderedScoreCalls = 0;
 
@@ -116,12 +116,12 @@ test("checkSakuraScore caches successful rendered responses", async () => {
 });
 
 test("checkSakuraScore ignores malformed cached successes and refetches", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const cleanup = installChromeStorageStub();
   let fetchRenderedScoreCalls = 0;
 
   try {
-    await apiClient.writeCache("B08N5WRWNW", {
+    await apiClient.__testing.writeCache("B08N5WRWNW", {
       ok: true,
       fetchedAt: new Date().toISOString(),
       sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjA4TjVXUldOVw==",
@@ -158,7 +158,7 @@ test("checkSakuraScore ignores malformed cached successes and refetches", async 
 });
 
 test("checkSakuraScore returns blocked when rendered extraction is blocked", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const result = await apiClient.checkSakuraScore({
     asin: "B08N5WRWNW",
     forceRefresh: true,
@@ -176,7 +176,7 @@ test("checkSakuraScore returns blocked when rendered extraction is blocked", asy
 });
 
 test("checkSakuraScore rejects successful responses that do not include a usable score", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const result = await apiClient.checkSakuraScore({
     asin: "B08N5WRWNW",
     forceRefresh: true,
@@ -198,7 +198,7 @@ test("checkSakuraScore rejects successful responses that do not include a usable
 });
 
 test("checkSakuraScore accepts text-based itemsearch scores", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const result = await apiClient.checkSakuraScore({
     asin: "B091BGMKYS",
     forceRefresh: true,
@@ -225,7 +225,7 @@ test("checkSakuraScore accepts text-based itemsearch scores", async () => {
 });
 
 test("checkSakuraScore returns not_found when the product is missing", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const result = await apiClient.checkSakuraScore({
     asin: "B08N5WRWNW",
     forceRefresh: true,
@@ -243,7 +243,7 @@ test("checkSakuraScore returns not_found when the product is missing", async () 
 });
 
 test("checkSakuraScore deduplicates concurrent requests for the same ASIN", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   let fetchRenderedScoreCalls = 0;
   let resolveRequest = null;
 
@@ -287,7 +287,7 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN", asyn
 });
 
 test("checkSakuraScore serializes concurrent requests for different ASINs", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const startedAsins = [];
   const resolvers = [];
   let activeRequests = 0;
@@ -351,7 +351,7 @@ test("checkSakuraScore serializes concurrent requests for different ASINs", asyn
 });
 
 test("checkSakuraScore continues the queue after a request throws", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const startedAsins = [];
 
   const fetchRenderedScoreImpl = async ({ asin }) => {
@@ -395,7 +395,7 @@ test("checkSakuraScore continues the queue after a request throws", async () => 
 });
 
 test("checkSakuraScore applies a global request interval between ASINs", async () => {
-  apiClient.__resetForTests();
+  apiClient.__testing.reset();
   const waits = [];
 
   const fetchRenderedScoreImpl = async () => ({

--- a/tests/asin-utils.test.js
+++ b/tests/asin-utils.test.js
@@ -1,0 +1,21 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const asinUtils = require("../shared/asin-utils.js");
+
+test("extractAsinFromPath supports Amazon product URL variants", () => {
+  assert.equal(asinUtils.extractAsinFromPath("/dp/B095JGJCC7"), "B095JGJCC7");
+  assert.equal(asinUtils.extractAsinFromPath("/gp/product/B095JGJCC7/"), "B095JGJCC7");
+  assert.equal(asinUtils.extractAsinFromPath("/gp/aw/d/B095JGJCC7"), "B095JGJCC7");
+});
+
+test("extractAsinFromUrl parses canonical and mobile product URLs", () => {
+  assert.equal(
+    asinUtils.extractAsinFromUrl("https://www.amazon.co.jp/gp/aw/d/B095JGJCC7?smid=test"),
+    "B095JGJCC7"
+  );
+  assert.equal(
+    asinUtils.extractAsinFromUrl("https://www.amazon.co.jp/gp/product/B095JGJCC7/ref=something"),
+    "B095JGJCC7"
+  );
+});

--- a/tests/browser-compare.test.js
+++ b/tests/browser-compare.test.js
@@ -5,8 +5,6 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
 
-const renderedParser = require("../background/rendered-score-parser.js");
-
 const CHROME_PATHS = [
   "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
   "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
@@ -15,6 +13,10 @@ const CHROME_PATHS = [
 ];
 const WAIT_TIMEOUT_MS = 30000;
 const browserCompareEnabled = process.env.ENABLE_BROWSER_COMPARE === "1";
+const parserScriptSource = fs.readFileSync(
+  path.join(__dirname, "..", "background", "rendered-score-parser.js"),
+  "utf8"
+);
 
 function getChromePath() {
   return CHROME_PATHS.find((candidate) => fs.existsSync(candidate)) || null;
@@ -229,7 +231,16 @@ async function waitForSakuraPageReady(cdpClient, asin) {
 }
 
 async function waitForRenderedPrimaryScore(cdpClient, extractSource, asin) {
-  const expression = `(${extractSource})(document, ${JSON.stringify(asin)})`;
+  const expression = `(() => {
+    if (
+      !self.RenderedScoreParser ||
+      typeof self.RenderedScoreParser.extractRenderedScore !== "function"
+    ) {
+      (0, eval)(${JSON.stringify(extractSource)});
+    }
+
+    return self.RenderedScoreParser.extractRenderedScore(document, ${JSON.stringify(asin)});
+  })()`;
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
@@ -377,7 +388,7 @@ test("browser-rendered top score visually matches the rendered DOM extractor out
 }, async () => {
   const asin = "B095JGJCC7";
   const url = `https://sakura-checker.jp/search/${asin}/`;
-  const extractSource = renderedParser.extractRenderedScore.toString();
+  const extractSource = parserScriptSource;
 
   const session = await launchChrome(chromePath);
 

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -205,6 +205,7 @@ function createPageDocument(url) {
 }
 
 function createExecutionContext({ document, chrome } = {}) {
+  const mutationObservers = [];
   const context = {
     console,
     document: document || createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7"),
@@ -212,6 +213,7 @@ function createExecutionContext({ document, chrome } = {}) {
     MutationObserver: class {
       constructor(callback) {
         this.callback = callback;
+        mutationObservers.push(this);
       }
 
       observe() {}
@@ -225,6 +227,7 @@ function createExecutionContext({ document, chrome } = {}) {
   context.self = context;
   context.location = context.document.location;
   context.globalThis = context;
+  context.__mutationObservers = mutationObservers;
 
   return vm.createContext(context);
 }
@@ -377,6 +380,61 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(images[0].src, "data:image/png;base64,AAA");
   assert.equal(images[1].src, "data:image/png;base64,BBB");
   assert.equal(images[2].src, "https://sakura-checker.jp/images/rv_level03.png");
+});
+
+test("SakuraChecker keeps the first response when the URL changes to the same ASIN during fetch", async () => {
+  const document = createPageDocument("https://www.amazon.co.jp/gp/product/B095JGJCC7");
+  const sendMessageCalls = [];
+  let resolveResponse = null;
+  const chrome = {
+    runtime: {
+      sendMessage: async (payload) =>
+        new Promise((resolve) => {
+          sendMessageCalls.push(payload);
+          resolveResponse = resolve;
+        }),
+    },
+  };
+  const context = createExecutionContext({ document, chrome });
+
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+  loadScript(context, "content/ui-display.js");
+  loadScript(context, "content/sakura-checker.js");
+
+  context.window.SakuraChecker.observePageChanges();
+  const refreshPromise = context.window.SakuraChecker.refreshForCurrentPage();
+
+  context.document.location = new URL("https://www.amazon.co.jp/dp/B095JGJCC7?th=1");
+  context.window.location = context.document.location;
+  context.location = context.document.location;
+  context.__mutationObservers[0].callback();
+
+  resolveResponse({
+    ok: true,
+    cached: false,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  await refreshPromise;
+
+  const root = document.getElementById("sakura-checker-result");
+  assert.ok(root);
+  assert.equal(root.dataset.state, "success");
+  assert.equal(sendMessageCalls.length, 1);
+
+  const scoreText = findByClass(root, "sc-score-text");
+  assert.ok(scoreText);
+  assert.equal(scoreText.textContent, "4.29");
 });
 
 test("UiDisplay renders text-based itemsearch scores", () => {

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -275,6 +275,7 @@ test("content.js initializes SakuraChecker immediately after document_end", () =
 test("UiDisplay renders the panel after the Amazon title area", () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   const context = createExecutionContext({ document });
+  loadScript(context, "shared/asin-utils.js");
   loadScript(context, "content/ui-display.js");
 
   context.window.UiDisplay.renderLoading(
@@ -298,6 +299,7 @@ test("AsinExtractor ignores search result data-asin entries on non-product pages
   document.body.appendChild(searchResult);
 
   const context = createExecutionContext({ document });
+  loadScript(context, "shared/asin-utils.js");
   loadScript(context, "content/asin-extractor.js");
 
   assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
@@ -312,6 +314,7 @@ test("AsinExtractor reads the canonical product URL when pathname is not a produ
   document.head.appendChild(canonical);
 
   const context = createExecutionContext({ document });
+  loadScript(context, "shared/asin-utils.js");
   loadScript(context, "content/asin-extractor.js");
 
   assert.equal(context.window.AsinExtractor.extractProductASIN(), "B095JGJCC7");
@@ -331,11 +334,12 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   };
   const context = createExecutionContext({ document, chrome });
 
+  loadScript(context, "shared/asin-utils.js");
   loadScript(context, "content/asin-extractor.js");
   loadScript(context, "content/ui-display.js");
   loadScript(context, "content/sakura-checker.js");
 
-  const refreshPromise = context.window.SakuraChecker.refreshForCurrentPage(false);
+  const refreshPromise = context.window.SakuraChecker.refreshForCurrentPage();
 
   const loadingRoot = document.getElementById("sakura-checker-result");
   assert.ok(loadingRoot);
@@ -425,11 +429,12 @@ test("SakuraChecker does not render or fetch on non-product pages that contain s
   };
   const context = createExecutionContext({ document, chrome });
 
+  loadScript(context, "shared/asin-utils.js");
   loadScript(context, "content/asin-extractor.js");
   loadScript(context, "content/ui-display.js");
   loadScript(context, "content/sakura-checker.js");
 
-  await context.window.SakuraChecker.refreshForCurrentPage(false);
+  await context.window.SakuraChecker.refreshForCurrentPage();
 
   assert.equal(sendMessageCalled, false);
   assert.equal(document.getElementById("sakura-checker-result"), null);

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -463,6 +463,28 @@ const ambiguousWrapperWithModernHtml = `
   </html>
 `;
 
+const targetedRenderedLoadingWithModernHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div class="item-review-wrap">
+        <div class="item-image">
+          <a href="https://www.amazon.co.jp/dp/B0OTHER999/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+        </div>
+        ${targetedSecondaryItemInfo}
+      </div>
+      <div class="item-review-wrap">
+        <div class="item-image">
+          <a href="https://www.amazon.co.jp/dp/B0TARGET42/?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+        </div>
+        <div id="target-loader" class="loader"></div>
+      </div>
+      ${modernSakuraAlertMarkup}
+      ${modernSakuraRatingMarkup}
+    </body>
+  </html>
+`;
+
 const modernInjectedHtml = `
   <!DOCTYPE html>
   <html lang="ja">
@@ -621,6 +643,7 @@ module.exports = {
   sameWrapReviewCountTiebreakHtml,
   scrambledScoreValue,
   targetedRenderedLoadingHtml,
+  targetedRenderedLoadingWithModernHtml,
   targetedRenderedProductHtml,
   targetReviewWrap,
   verdictImageTag,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,8 +1,8 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const { chromium } = require("playwright");
-
-const renderedParser = require("../background/rendered-score-parser.js");
 
 const knownAsins = ["B0921THFXZ", "B095JGJCC7"];
 const retryDelaysMs = [1000, 3000];
@@ -11,6 +11,10 @@ const liveSmokeTestTimeoutMs =
   (retryDelaysMs.length + 1) * (renderTimeoutMs * 2) +
   retryDelaysMs.reduce((total, delayMs) => total + delayMs, 0) +
   10000;
+const parserScriptSource = fs.readFileSync(
+  path.join(__dirname, "..", "background", "rendered-score-parser.js"),
+  "utf8"
+);
 
 function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -43,13 +47,22 @@ function isSupportedSuffix(value) {
 }
 
 async function extractRenderedScore(page, asin) {
-  return page.evaluate(({ extractSource, asin: requestedAsin }) => {
-    const extract = Function(`return (${extractSource});`)();
-    return extract(document, requestedAsin);
-  }, {
-    extractSource: renderedParser.extractRenderedScore.toString(),
-    asin,
-  });
+  return page.evaluate(
+    ({ parserSource, asin: requestedAsin }) => {
+      if (
+        !window.RenderedScoreParser ||
+        typeof window.RenderedScoreParser.extractRenderedScore !== "function"
+      ) {
+        (0, eval)(parserSource);
+      }
+
+      return window.RenderedScoreParser.extractRenderedScore(document, requestedAsin);
+    },
+    {
+      parserSource: parserScriptSource,
+      asin,
+    }
+  );
 }
 
 async function waitForRenderedScore(page, asin) {

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -7,13 +7,14 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
+function installChromeStub({ completeDelayMs = 0, parserInjectionResponder, scriptResponder }) {
   const listeners = new Set();
   const tabs = new Map();
   const createCalls = [];
   const removeCalls = [];
   let nextTabId = 1;
   let executeCalls = 0;
+  let parserInjectionCalls = 0;
   let extractCalls = 0;
   const executeDetails = [];
 
@@ -63,7 +64,16 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
         executeCalls += 1;
         executeDetails.push(details);
         if (Array.isArray(details.files)) {
+          parserInjectionCalls += 1;
+          const injectionErrorMessage =
+            typeof parserInjectionResponder === "function"
+              ? parserInjectionResponder(details, parserInjectionCalls)
+              : null;
+          global.chrome.runtime.lastError = injectionErrorMessage
+            ? { message: injectionErrorMessage }
+            : null;
           callback([{ result: null }]);
+          global.chrome.runtime.lastError = null;
           return;
         }
         extractCalls += 1;
@@ -84,6 +94,9 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
     },
     get extractCalls() {
       return extractCalls;
+    },
+    get parserInjectionCalls() {
+      return parserInjectionCalls;
     },
     executeDetails,
     cleanup() {
@@ -132,6 +145,44 @@ test("fetchRenderedScore creates a temporary tab, polls, and closes it on succes
     assert.ok(stub.extractCalls >= 2);
     assert.deepEqual(stub.executeDetails[0].files, ["background/rendered-score-parser.js"]);
     assert.deepEqual(stub.executeDetails[1].args, ["B095JGJCC7"]);
+  } finally {
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore retries transient parser injection failures before polling", async () => {
+  const stub = installChromeStub({
+    parserInjectionResponder(_details, callCount) {
+      if (callCount === 1) {
+        return "The tab is still navigating.";
+      }
+
+      return null;
+    },
+    scriptResponder() {
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "4" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B095JGJCC7",
+      sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+      timeoutMs: 200,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(stub.parserInjectionCalls, 2);
+    assert.equal(stub.extractCalls, 1);
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -61,6 +61,10 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
       executeScript(details, callback) {
         executeCalls += 1;
         executeDetails.push(details);
+        if (Array.isArray(details.files)) {
+          callback([{ result: null }]);
+          return;
+        }
         callback([
           {
             result: scriptResponder(details, executeCalls),
@@ -121,7 +125,8 @@ test("fetchRenderedScore creates a temporary tab, polls, and closes it on succes
     assert.equal(stub.createCalls[0].active, false);
     assert.equal(stub.removeCalls.length, 1);
     assert.ok(stub.executeCalls >= 2);
-    assert.deepEqual(stub.executeDetails[0].args, ["B095JGJCC7"]);
+    assert.deepEqual(stub.executeDetails[0].files, ["background/rendered-score-parser.js"]);
+    assert.deepEqual(stub.executeDetails[1].args, ["B095JGJCC7"]);
   } finally {
     stub.cleanup();
   }
@@ -150,7 +155,7 @@ test("fetchRenderedScore closes the temporary tab after a render timeout", async
     assert.equal(result.ok, false);
     assert.equal(result.code, "parse_error");
     assert.equal(stub.removeCalls.length, 1);
-    assert.ok(stub.executeCalls > 1);
+    assert.ok(stub.executeCalls > 2);
   } finally {
     stub.cleanup();
   }
@@ -180,7 +185,7 @@ test("fetchRenderedScore returns terminal extraction errors without retrying for
     assert.equal(result.code, "parse_error");
     assert.equal(result.message, "Broken markup");
     assert.equal(stub.removeCalls.length, 1);
-    assert.equal(stub.executeCalls, 1);
+    assert.equal(stub.executeCalls, 2);
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -14,6 +14,7 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
   const removeCalls = [];
   let nextTabId = 1;
   let executeCalls = 0;
+  let extractCalls = 0;
   const executeDetails = [];
 
   global.chrome = {
@@ -65,9 +66,10 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
           callback([{ result: null }]);
           return;
         }
+        extractCalls += 1;
         callback([
           {
-            result: scriptResponder(details, executeCalls),
+            result: scriptResponder(details, extractCalls),
           },
         ]);
       },
@@ -79,6 +81,9 @@ function installChromeStub({ completeDelayMs = 0, scriptResponder }) {
     removeCalls,
     get executeCalls() {
       return executeCalls;
+    },
+    get extractCalls() {
+      return extractCalls;
     },
     executeDetails,
     cleanup() {
@@ -124,7 +129,7 @@ test("fetchRenderedScore creates a temporary tab, polls, and closes it on succes
     assert.equal(stub.createCalls.length, 1);
     assert.equal(stub.createCalls[0].active, false);
     assert.equal(stub.removeCalls.length, 1);
-    assert.ok(stub.executeCalls >= 2);
+    assert.ok(stub.extractCalls >= 2);
     assert.deepEqual(stub.executeDetails[0].files, ["background/rendered-score-parser.js"]);
     assert.deepEqual(stub.executeDetails[1].args, ["B095JGJCC7"]);
   } finally {
@@ -155,7 +160,7 @@ test("fetchRenderedScore closes the temporary tab after a render timeout", async
     assert.equal(result.ok, false);
     assert.equal(result.code, "parse_error");
     assert.equal(stub.removeCalls.length, 1);
-    assert.ok(stub.executeCalls > 2);
+    assert.ok(stub.extractCalls > 1);
   } finally {
     stub.cleanup();
   }
@@ -185,7 +190,7 @@ test("fetchRenderedScore returns terminal extraction errors without retrying for
     assert.equal(result.code, "parse_error");
     assert.equal(result.message, "Broken markup");
     assert.equal(stub.removeCalls.length, 1);
-    assert.equal(stub.executeCalls, 2);
+    assert.equal(stub.extractCalls, 1);
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -118,6 +118,17 @@ test("extractRenderedScore waits when only unrelated legacy cards are rendered f
   assert.equal(result.retryable, true);
 });
 
+test("extractRenderedScore prefers the modern summary over a pending legacy card", () => {
+  const document = parseDocument(fixtures.targetedRenderedLoadingWithModernHtml);
+  const result = renderedParser.extractRenderedScore(document, "B0TARGET42");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.suffix, "%");
+  assert.equal(result.score.images.length, 1);
+  assert.ok(result.verdict);
+  assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/sakura_lv00.png");
+});
+
 test("extractRenderedScore falls back to the rendered modern summary when needed", () => {
   const document = parseDocument(fixtures.fixedRenderedModernHtml);
   const result = renderedParser.extractRenderedScore(document);


### PR DESCRIPTION
## Summary
- clean up maintainability issues by removing unused refresh wiring and sharing ASIN parsing logic
- refactor the background client and rendered score parser, and switch hidden-tab extraction to inject the parser file instead of passing the parser function around
- bump the extension patch version to 2.1.1 and keep manifest/package versions in sync

## Validation
- npm test
- npm run test:live
- npm run test:e2e-extension
- npm run test:browser-compare

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **ASIN抽出ロジックを shared/asin-utils.js に集約** - 複数ファイルで重複していたASIN抽出処理を共有モジュール化。コード重複を排除し保守性を向上。

- **パーサーインジェクション方式に変更** - background/rendered-score-client.js が chrome.scripting.executeScript でパーサーファイルを直接注入する方式へ。関数の受け渡しを廃止し結合度を低減。

- **APIクライアントを関数型インターフェースに統一** - background/api-client.js でストレージ、キャッシュ、リクエスト調整をファクトリ関数化。テストの独立性と依存性注入を改善。

- **不要な forceRefresh パラメータを削除** - content/sakura-checker.js と content/asin-extractor.js から未使用のオプション引数を削除。API表面を簡潔化。

- **バージョン 2.1.0 → 2.1.1 へ更新** - manifest.json、package.json、新規 shared/asin-utils.js をビルド対象に追加。メンテナンス改善のリリース。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->