### PR TITLE
Add URL search fallback for missing Sakura Checker results

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -36,6 +36,10 @@
     return `https://sakura-checker.jp/search/${asin}/`;
   }
 
+  function buildAmazonProductUrl(asin) {
+    return `https://www.amazon.co.jp/dp/${encodeURIComponent(String(asin || ""))}`;
+  }
+
   function resolveSakuraUrl(value) {
     if (!value) {
       return value;
@@ -271,6 +275,10 @@
     );
   }
 
+  function shouldRetryWithProductUrl(renderedResult) {
+    return Boolean(renderedResult && renderedResult.code === "url_search_required");
+  }
+
   async function fetchFreshScore({
     asin,
     fetchRenderedScore,
@@ -299,6 +307,22 @@
         error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
         sourceUrl
       );
+    }
+
+    if (shouldRetryWithProductUrl(renderedResult)) {
+      try {
+        renderedResult = await fetchRenderedScore({
+          asin,
+          sourceUrl,
+          urlSearchProductUrl: buildAmazonProductUrl(asin),
+        });
+      } catch (error) {
+        return createFailure(
+          "network_error",
+          error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
+          sourceUrl
+        );
+      }
     }
 
     if (!renderedResult || !renderedResult.ok) {
@@ -373,6 +397,7 @@
   }
 
   return {
+    buildAmazonProductUrl,
     buildDetailUrl,
     buildSourceUrl,
     checkSakuraScore,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -233,7 +233,9 @@
   }
 
   function waitForTabReload(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {
-    return new Promise((resolve, reject) => {
+    let cleanup = () => {};
+
+    const promise = new Promise((resolve, reject) => {
       if (
         typeof chrome === "undefined" ||
         !chrome.tabs ||
@@ -248,7 +250,7 @@
       let sawLoading = false;
       let timeoutId = null;
 
-      function cleanup() {
+      cleanup = () => {
         if (settled) {
           return;
         }
@@ -283,11 +285,17 @@
 
       chrome.tabs.onUpdated.addListener(handleUpdated);
     });
+
+    return {
+      promise,
+      cancel() {
+        cleanup();
+      },
+    };
   }
 
   async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TIMEOUT_MS) {
-    const reloadPromise = waitForTabReload(tabId, timeoutMs);
-    const reloadDrainPromise = reloadPromise.catch(() => {});
+    const reloadHandle = waitForTabReload(tabId, timeoutMs);
     let submissionResult = null;
 
     try {
@@ -318,19 +326,31 @@
             };
           }
 
-          form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-          return { ok: true, method: "submit" };
+          if (typeof form.requestSubmit === "function") {
+            form.requestSubmit();
+            return { ok: true, method: "requestSubmit" };
+          }
+
+          if (typeof form.submit === "function") {
+            form.submit();
+            return { ok: true, method: "submit" };
+          }
+
+          return {
+            ok: false,
+            message: "The Sakura Checker search form could not be submitted.",
+          };
         },
         [amazonProductUrl],
         "Failed to submit the Sakura Checker URL search."
       );
     } catch (error) {
-      void reloadDrainPromise;
+      reloadHandle.cancel();
       throw error;
     }
 
     if (!submissionResult || submissionResult.ok !== true) {
-      void reloadDrainPromise;
+      reloadHandle.cancel();
       throw new Error(
         submissionResult && submissionResult.message
           ? submissionResult.message
@@ -338,7 +358,7 @@
       );
     }
 
-    await reloadPromise;
+    await reloadHandle.promise;
   }
 
   function waitForTabComplete(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -198,6 +198,140 @@
     });
   }
 
+  function executeTabFunction(tabId, func, args = [], defaultMessage = "Failed to run a script.") {
+    return new Promise((resolve, reject) => {
+      if (
+        typeof chrome === "undefined" ||
+        !chrome.scripting ||
+        typeof chrome.scripting.executeScript !== "function"
+      ) {
+        reject(new Error("chrome.scripting.executeScript is not available."));
+        return;
+      }
+
+      chrome.scripting.executeScript(
+        {
+          target: { tabId },
+          func,
+          args,
+        },
+        (injectionResults) => {
+          if (
+            typeof chrome !== "undefined" &&
+            chrome.runtime &&
+            chrome.runtime.lastError
+          ) {
+            reject(createChromeError(defaultMessage));
+            return;
+          }
+
+          const firstResult = Array.isArray(injectionResults) ? injectionResults[0] : null;
+          resolve(firstResult ? firstResult.result : null);
+        }
+      );
+    });
+  }
+
+  function waitForTabReload(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    return new Promise((resolve, reject) => {
+      if (
+        typeof chrome === "undefined" ||
+        !chrome.tabs ||
+        !chrome.tabs.onUpdated ||
+        typeof chrome.tabs.onUpdated.addListener !== "function"
+      ) {
+        reject(new Error("chrome.tabs.onUpdated is not available."));
+        return;
+      }
+
+      let settled = false;
+      let sawLoading = false;
+      let timeoutId = null;
+
+      function cleanup() {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+        }
+        chrome.tabs.onUpdated.removeListener(handleUpdated);
+      }
+
+      function handleUpdated(updatedTabId, changeInfo, tab) {
+        if (updatedTabId !== tabId) {
+          return;
+        }
+
+        if (changeInfo.status === "loading") {
+          sawLoading = true;
+          return;
+        }
+
+        if (sawLoading && (changeInfo.status === "complete" || (tab && tab.status === "complete"))) {
+          cleanup();
+          resolve(tab || { id: tabId, status: "complete" });
+        }
+      }
+
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error("Timed out waiting for the Sakura Checker page to reload."));
+      }, timeoutMs);
+
+      chrome.tabs.onUpdated.addListener(handleUpdated);
+    });
+  }
+
+  async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    const reloadPromise = waitForTabReload(tabId, timeoutMs);
+    const submissionResult = await executeTabFunction(
+      tabId,
+      (productUrl) => {
+        const input = document.querySelector("#urlsearchForm");
+        if (!input) {
+          return {
+            ok: false,
+            message: "The Sakura Checker search input is not available.",
+          };
+        }
+
+        input.value = productUrl;
+        input.setAttribute("value", productUrl);
+
+        if (typeof self.setactionsearchForm === "function") {
+          self.setactionsearchForm(true);
+          return { ok: true, method: "setactionsearchForm" };
+        }
+
+        const form = document.querySelector("#searchForm");
+        if (!form) {
+          return {
+            ok: false,
+            message: "The Sakura Checker search form is not available.",
+          };
+        }
+
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        return { ok: true, method: "submit" };
+      },
+      [amazonProductUrl],
+      "Failed to submit the Sakura Checker URL search."
+    );
+
+    if (!submissionResult || submissionResult.ok !== true) {
+      throw new Error(
+        submissionResult && submissionResult.message
+          ? submissionResult.message
+          : "Could not submit the Sakura Checker URL search."
+      );
+    }
+
+    await reloadPromise;
+  }
+
   function waitForTabComplete(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
       if (
@@ -309,7 +443,13 @@
     };
   }
 
-  async function fetchRenderedScore({ asin, sourceUrl, timeoutMs, pollIntervalMs }) {
+  async function fetchRenderedScore({
+    asin,
+    sourceUrl,
+    timeoutMs,
+    pollIntervalMs,
+    urlSearchProductUrl,
+  }) {
     let tab = null;
 
     try {
@@ -319,6 +459,9 @@
       });
 
       await waitForTabComplete(tab.id, timeoutMs);
+      if (typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()) {
+        await submitProductUrlSearch(tab.id, urlSearchProductUrl, timeoutMs);
+      }
       await injectParserWithRetry(tab.id, {
         timeoutMs,
         pollIntervalMs,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -287,41 +287,50 @@
 
   async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TIMEOUT_MS) {
     const reloadPromise = waitForTabReload(tabId, timeoutMs);
-    const submissionResult = await executeTabFunction(
-      tabId,
-      (productUrl) => {
-        const input = document.querySelector("#urlsearchForm");
-        if (!input) {
-          return {
-            ok: false,
-            message: "The Sakura Checker search input is not available.",
-          };
-        }
+    const reloadDrainPromise = reloadPromise.catch(() => {});
+    let submissionResult = null;
 
-        input.value = productUrl;
-        input.setAttribute("value", productUrl);
+    try {
+      submissionResult = await executeTabFunction(
+        tabId,
+        (productUrl) => {
+          const input = document.querySelector("#urlsearchForm");
+          if (!input) {
+            return {
+              ok: false,
+              message: "The Sakura Checker search input is not available.",
+            };
+          }
 
-        if (typeof self.setactionsearchForm === "function") {
-          self.setactionsearchForm(true);
-          return { ok: true, method: "setactionsearchForm" };
-        }
+          input.value = productUrl;
+          input.setAttribute("value", productUrl);
 
-        const form = document.querySelector("#searchForm");
-        if (!form) {
-          return {
-            ok: false,
-            message: "The Sakura Checker search form is not available.",
-          };
-        }
+          if (typeof self.setactionsearchForm === "function") {
+            self.setactionsearchForm(true);
+            return { ok: true, method: "setactionsearchForm" };
+          }
 
-        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-        return { ok: true, method: "submit" };
-      },
-      [amazonProductUrl],
-      "Failed to submit the Sakura Checker URL search."
-    );
+          const form = document.querySelector("#searchForm");
+          if (!form) {
+            return {
+              ok: false,
+              message: "The Sakura Checker search form is not available.",
+            };
+          }
+
+          form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+          return { ok: true, method: "submit" };
+        },
+        [amazonProductUrl],
+        "Failed to submit the Sakura Checker URL search."
+      );
+    } catch (error) {
+      void reloadDrainPromise;
+      throw error;
+    }
 
     if (!submissionResult || submissionResult.ok !== true) {
+      void reloadDrainPromise;
       throw new Error(
         submissionResult && submissionResult.message
           ? submissionResult.message

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -78,6 +78,14 @@
       return location.pathname;
     }
 
+    try {
+      if (context.root.baseURI) {
+        return new URL(context.root.baseURI).pathname;
+      }
+    } catch {
+      // Ignore baseURI parsing issues and fall back.
+    }
+
     return "";
   }
 
@@ -552,6 +560,30 @@
     return null;
   }
 
+  function detectUrlSearchRequired(context) {
+    if (!/\/itemsearch\/?/i.test(currentPathname(context))) {
+      return null;
+    }
+
+    const bodyText = normalizeText(
+      (context.root.body && context.root.body.textContent) || context.root.textContent || ""
+    );
+
+    if (
+      bodyText.includes("商品名検索では商品が見つかりませんでした。") &&
+      bodyText.includes("アマゾン製品URLでのURL検索をお試し下さい。") &&
+      bodyText.includes("URLでは必ず検出できます。")
+    ) {
+      return createFailure(
+        "url_search_required",
+        "Sakura Checker asked for an Amazon product URL search.",
+        false
+      );
+    }
+
+    return null;
+  }
+
   function buildFallbackResult(context) {
     const hasLoadingSignals = Boolean(
       context.root.querySelector(".loader, .loading, .item-review-wrap, .sakuraBlock, #pagetop")
@@ -589,6 +621,11 @@
     const itemSearch = extractItemSearchScore(context);
     if (itemSearch) {
       return itemSearch;
+    }
+
+    const urlSearchRequired = detectUrlSearchRequired(context);
+    if (urlSearchRequired) {
+      return urlSearchRequired;
     }
 
     const legacy = extractLegacyScore(context);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.0.2",
+      "version": "2.1.2",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -295,6 +295,64 @@ test("checkSakuraScore falls back to an Amazon product URL search when itemsearc
   });
 });
 
+test("checkSakuraScore returns the fallback error when URL-search retry also fails", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0BJDY6D1W",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      return {
+        ok: false,
+        code: "blocked",
+        message: "Sakura Checker temporarily blocked the request.",
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "blocked");
+  assert.equal(calls.length, 2);
+});
+
+test("checkSakuraScore stops after one fallback when URL-search retry still requires a product URL", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0BJDY6D1W",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      return {
+        ok: false,
+        code: "url_search_required",
+        message: "Sakura Checker asked for an Amazon product URL search.",
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "url_search_required");
+  assert.equal(calls.length, 2);
+});
+
 test("checkSakuraScore deduplicates concurrent requests for the same ASIN", async () => {
   apiClient.__testing.reset();
   let fetchRenderedScoreCalls = 0;

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -49,6 +49,14 @@ test("buildDetailUrl creates the Sakura Checker detail URL", () => {
   );
 });
 
+test("buildAmazonProductUrl creates the canonical Amazon product URL", () => {
+  apiClient.__testing.reset();
+  assert.equal(
+    apiClient.buildAmazonProductUrl("B08N5WRWNW"),
+    "https://www.amazon.co.jp/dp/B08N5WRWNW"
+  );
+});
+
 test("encodeItemSearchWord base64-encodes the ASIN", () => {
   assert.equal(apiClient.encodeItemSearchWord("B091BGMKYS"), "QjA5MUJHTUtZUw==");
 });
@@ -240,6 +248,51 @@ test("checkSakuraScore returns not_found when the product is missing", async () 
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "not_found");
+});
+
+test("checkSakuraScore falls back to an Amazon product URL search when itemsearch requires it", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0BJDY6D1W",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "score" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], {
+    asin: "B0BJDY6D1W",
+    sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjBCSkRZNkQxVw==",
+  });
+  assert.deepEqual(calls[1], {
+    asin: "B0BJDY6D1W",
+    sourceUrl: "https://sakura-checker.jp/search/B0BJDY6D1W/",
+    urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0BJDY6D1W",
+  });
 });
 
 test("checkSakuraScore deduplicates concurrent requests for the same ASIN", async () => {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -590,6 +590,18 @@ const itemSearchResultHtml = `
   </html>
 `;
 
+const itemSearchNoResultsHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div id="javascriptEnabled">
+        <p>商品名検索では商品が見つかりませんでした。</p>
+        <p>アマゾン製品URLでのURL検索をお試し下さい。URLでは必ず検出できます。</p>
+      </div>
+    </body>
+  </html>
+`;
+
 const productAndModernHtml = sampleHtml.replace(
   "</body>",
   `
@@ -619,6 +631,7 @@ module.exports = {
   comparisonPrimaryItemInfo,
   comparisonSecondaryItemInfo,
   htmlWithInjectedScore,
+  itemSearchNoResultsHtml,
   itemSearchResultHtml,
   injectedDecodedScript,
   injectedPayload,

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -77,6 +77,27 @@ function installChromeStub({ completeDelayMs = 0, parserInjectionResponder, scri
           return;
         }
         extractCalls += 1;
+        if (
+          Array.isArray(details.args) &&
+          details.args.length === 1 &&
+          typeof details.args[0] === "string" &&
+          /amazon\.co\.jp\/dp\//.test(details.args[0])
+        ) {
+          const tab = tabs.get(details.target.tabId);
+          if (tab) {
+            tab.status = "loading";
+            for (const listener of listeners) {
+              listener(tab.id, { status: "loading" }, tab);
+            }
+
+            setTimeout(() => {
+              tab.status = "complete";
+              for (const listener of listeners) {
+                listener(tab.id, { status: "complete" }, tab);
+              }
+            }, completeDelayMs);
+          }
+        }
         callback([
           {
             result: scriptResponder(details, extractCalls),
@@ -242,6 +263,69 @@ test("fetchRenderedScore returns terminal extraction errors without retrying for
     assert.equal(result.message, "Broken markup");
     assert.equal(stub.removeCalls.length, 1);
     assert.equal(stub.extractCalls, 1);
+  } finally {
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore can trigger a Sakura Checker product URL search before extracting", async () => {
+  const stub = installChromeStub({
+    scriptResponder(details) {
+      if (
+        Array.isArray(details.args) &&
+        details.args.length === 1 &&
+        typeof details.args[0] === "string" &&
+        /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
+      ) {
+        return {
+          ok: true,
+          method: "setactionsearchForm",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "4" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B0BJDY6D1W",
+      sourceUrl: "https://sakura-checker.jp/search/B0BJDY6D1W/",
+      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0BJDY6D1W",
+      timeoutMs: 200,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(stub.createCalls.length, 1);
+    assert.ok(stub.extractCalls >= 2);
+    assert.ok(
+      stub.executeDetails.some(
+        (details) =>
+          Array.isArray(details.args) &&
+          details.args[0] === "https://www.amazon.co.jp/dp/B0BJDY6D1W"
+      )
+    );
+    assert.ok(
+      stub.executeDetails.some(
+        (details) =>
+          Array.isArray(details.files) &&
+          details.files[0] === "background/rendered-score-parser.js"
+      )
+    );
+    assert.ok(
+      stub.executeDetails.some(
+        (details) => Array.isArray(details.args) && details.args[0] === "B0BJDY6D1W"
+      )
+    );
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -7,7 +7,12 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function installChromeStub({ completeDelayMs = 0, parserInjectionResponder, scriptResponder }) {
+function installChromeStub({
+  completeDelayMs = 0,
+  parserInjectionResponder,
+  scriptResponder,
+  simulateUrlSearchReload = true,
+}) {
   const listeners = new Set();
   const tabs = new Map();
   const createCalls = [];
@@ -78,6 +83,7 @@ function installChromeStub({ completeDelayMs = 0, parserInjectionResponder, scri
         }
         extractCalls += 1;
         if (
+          simulateUrlSearchReload &&
           Array.isArray(details.args) &&
           details.args.length === 1 &&
           typeof details.args[0] === "string" &&
@@ -327,6 +333,59 @@ test("fetchRenderedScore can trigger a Sakura Checker product URL search before 
       )
     );
   } finally {
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore drains the reload wait when URL search submission fails", async () => {
+  const stub = installChromeStub({
+    simulateUrlSearchReload: false,
+    scriptResponder(details) {
+      if (
+        Array.isArray(details.args) &&
+        details.args.length === 1 &&
+        typeof details.args[0] === "string" &&
+        /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
+      ) {
+        return {
+          ok: false,
+          message: "The Sakura Checker search form is not available.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "4" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+  const unhandledRejections = [];
+  const onUnhandledRejection = (error) => {
+    unhandledRejections.push(error);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  try {
+    await assert.rejects(
+      renderedScoreClient.fetchRenderedScore({
+        asin: "B0BJDY6D1W",
+        sourceUrl: "https://sakura-checker.jp/search/B0BJDY6D1W/",
+        urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0BJDY6D1W",
+        timeoutMs: 25,
+        pollIntervalMs: 1,
+      }),
+      /search form is not available/
+    );
+
+    await delay(40);
+    assert.deepEqual(unhandledRejections, []);
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandledRejection);
     stub.cleanup();
   }
 });

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -7,6 +7,77 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+function runUrlSearchScript(details, options = {}) {
+  const requestSubmitCalls = options.requestSubmitCalls || [];
+  const submitCalls = options.submitCalls || [];
+  const hasInput = options.hasInput !== false;
+  const hasForm = options.hasForm !== false;
+  const hasSetActionSearchForm = Boolean(options.hasSetActionSearchForm);
+  const hasRequestSubmit = options.hasRequestSubmit !== false;
+  const hasSubmit = options.hasSubmit !== false;
+  const productUrl = Array.isArray(details.args) ? details.args[0] : null;
+
+  const input = hasInput
+    ? {
+        value: "",
+        setAttribute(_name, value) {
+          this.value = value;
+        },
+      }
+    : null;
+  const form = hasForm
+    ? {
+        requestSubmit: hasRequestSubmit
+          ? () => {
+              requestSubmitCalls.push(productUrl);
+            }
+          : undefined,
+        submit: hasSubmit
+          ? () => {
+              submitCalls.push(productUrl);
+            }
+          : undefined,
+      }
+    : null;
+  const previousDocument = global.document;
+  const previousSelf = global.self;
+  const previousEvent = global.Event;
+
+  global.document = {
+    querySelector(selector) {
+      if (selector === "#urlsearchForm") {
+        return input;
+      }
+      if (selector === "#searchForm") {
+        return form;
+      }
+      return null;
+    },
+  };
+  global.self = hasSetActionSearchForm
+    ? {
+        setactionsearchForm() {
+          requestSubmitCalls.push(productUrl);
+        },
+      }
+    : {};
+  global.Event = class Event {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.bubbles = Boolean(init.bubbles);
+      this.cancelable = Boolean(init.cancelable);
+    }
+  };
+
+  try {
+    return details.func(...details.args);
+  } finally {
+    global.document = previousDocument;
+    global.self = previousSelf;
+    global.Event = previousEvent;
+  }
+}
+
 function installChromeStub({
   completeDelayMs = 0,
   parserInjectionResponder,
@@ -17,6 +88,8 @@ function installChromeStub({
   const tabs = new Map();
   const createCalls = [];
   const removeCalls = [];
+  const requestSubmitCalls = [];
+  const submitCalls = [];
   let nextTabId = 1;
   let executeCalls = 0;
   let parserInjectionCalls = 0;
@@ -106,7 +179,10 @@ function installChromeStub({
         }
         callback([
           {
-            result: scriptResponder(details, extractCalls),
+            result: scriptResponder(details, extractCalls, {
+              requestSubmitCalls,
+              submitCalls,
+            }),
           },
         ]);
       },
@@ -116,6 +192,8 @@ function installChromeStub({
   return {
     createCalls,
     removeCalls,
+    requestSubmitCalls,
+    submitCalls,
     get executeCalls() {
       return executeCalls;
     },
@@ -276,17 +354,18 @@ test("fetchRenderedScore returns terminal extraction errors without retrying for
 
 test("fetchRenderedScore can trigger a Sakura Checker product URL search before extracting", async () => {
   const stub = installChromeStub({
-    scriptResponder(details) {
+    scriptResponder(details, _callCount, submissionState) {
       if (
         Array.isArray(details.args) &&
         details.args.length === 1 &&
         typeof details.args[0] === "string" &&
         /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
       ) {
-        return {
-          ok: true,
-          method: "setactionsearchForm",
-        };
+        return runUrlSearchScript(details, {
+          requestSubmitCalls: submissionState.requestSubmitCalls,
+          submitCalls: submissionState.submitCalls,
+          hasSetActionSearchForm: true,
+        });
       }
 
       return {
@@ -312,26 +391,13 @@ test("fetchRenderedScore can trigger a Sakura Checker product URL search before 
 
     assert.equal(result.ok, true);
     assert.equal(stub.createCalls.length, 1);
-    assert.ok(stub.extractCalls >= 2);
-    assert.ok(
-      stub.executeDetails.some(
-        (details) =>
-          Array.isArray(details.args) &&
-          details.args[0] === "https://www.amazon.co.jp/dp/B0BJDY6D1W"
-      )
-    );
-    assert.ok(
-      stub.executeDetails.some(
-        (details) =>
-          Array.isArray(details.files) &&
-          details.files[0] === "background/rendered-score-parser.js"
-      )
-    );
-    assert.ok(
-      stub.executeDetails.some(
-        (details) => Array.isArray(details.args) && details.args[0] === "B0BJDY6D1W"
-      )
-    );
+    assert.equal(stub.extractCalls, 2);
+    assert.equal(stub.executeDetails.length, 3);
+    assert.deepEqual(stub.executeDetails[0].args, ["https://www.amazon.co.jp/dp/B0BJDY6D1W"]);
+    assert.deepEqual(stub.executeDetails[1].files, ["background/rendered-score-parser.js"]);
+    assert.deepEqual(stub.executeDetails[2].args, ["B0BJDY6D1W"]);
+    assert.deepEqual(stub.requestSubmitCalls, ["https://www.amazon.co.jp/dp/B0BJDY6D1W"]);
+    assert.deepEqual(stub.submitCalls, []);
   } finally {
     stub.cleanup();
   }
@@ -386,6 +452,51 @@ test("fetchRenderedScore drains the reload wait when URL search submission fails
     assert.deepEqual(unhandledRejections, []);
   } finally {
     process.removeListener("unhandledRejection", onUnhandledRejection);
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore falls back to form.submit when requestSubmit is unavailable", async () => {
+  const stub = installChromeStub({
+    scriptResponder(details, _callCount, submissionState) {
+      if (
+        Array.isArray(details.args) &&
+        details.args.length === 1 &&
+        typeof details.args[0] === "string" &&
+        /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
+      ) {
+        return runUrlSearchScript(details, {
+          requestSubmitCalls: submissionState.requestSubmitCalls,
+          submitCalls: submissionState.submitCalls,
+          hasRequestSubmit: false,
+        });
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "4" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B0BJDY6D1W",
+      sourceUrl: "https://sakura-checker.jp/search/B0BJDY6D1W/",
+      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0BJDY6D1W",
+      timeoutMs: 200,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(stub.requestSubmitCalls, []);
+    assert.deepEqual(stub.submitCalls, ["https://www.amazon.co.jp/dp/B0BJDY6D1W"]);
+  } finally {
     stub.cleanup();
   }
 });

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -42,6 +42,18 @@ test("extractRenderedScore reads the itemsearch row for the requested ASIN", () 
   assert.deepEqual(result.verdict.lines, ["危険", "サクラ度 90%"]);
 });
 
+test("extractRenderedScore reports when itemsearch asks for an Amazon product URL", () => {
+  const document = parseDocument(
+    fixtures.itemSearchNoResultsHtml,
+    "https://sakura-checker.jp/itemsearch/?word=QjBCSkRZNkQxVw=="
+  );
+  const result = renderedParser.extractRenderedScore(document, "B0BJDY6D1W");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "url_search_required");
+  assert.equal(result.retryable, false);
+});
+
 test("extractRenderedScore prefers the richest rendered product card", () => {
   const document = parseDocument(fixtures.comparisonHeavyProductHtml);
   const result = renderedParser.extractRenderedScore(document);


### PR DESCRIPTION
## Summary
- detect Sakura Checker itemsearch responses that require an Amazon product URL search
- retry missing products with a canonical https://www.amazon.co.jp/dp/<ASIN> URL submitted through the Sakura Checker search flow
- bump the extension patch version to 2.1.2 and add regression coverage for the parser, API client, and rendered-score client

## Testing
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Sakura Checkerで商品が見つからない場合のフォールバック機能を実装 / 初回検索で「url_search_required」が返された際に、Amazon商品URLで再検索するため
- パーサーにURL検索必須状態の検出ロジックを追加 / itemsearchページで特定の日本語メッセージを検出し、URL検索が必要な状況を識別するため
- レンダリングスコアクライアントにURL検索フロー機能を追加 / Sakura Checkerの検索フォームに商品URLを送信し、ページリロード完了後に結果を取得するため
- 新機能の回帰テストを追加 / APIクライアント、パーサー、レンダリングスコアクライアントの新機能が正常に動作することを検証するため
- 拡張機能のバージョンを2.1.1から2.1.2に更新 / 新機能のリリースに対応するため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->