### PR TITLE
Add explicit cache refresh to the score panel

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,6 +10,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 
   self.ApiClient.checkSakuraScore({
     asin: request.asin,
+    forceRefresh: request.forceRefresh === true,
   })
     .then((result) => sendResponse(result))
     .catch((error) => {

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -4,6 +4,7 @@
       this.currentAsin = null;
       this.inFlight = false;
       this.pendingRefresh = false;
+      this.pendingForceRefresh = false;
     }
 
     init() {
@@ -19,7 +20,7 @@
       return window.AsinExtractor.extractProductASIN();
     }
 
-    async refreshForCurrentPage() {
+    async refreshForCurrentPage({ forceRefresh = false } = {}) {
       if (!window.AsinExtractor || !window.UiDisplay) {
         return;
       }
@@ -29,17 +30,20 @@
         window.UiDisplay.remove();
         this.currentAsin = null;
         this.pendingRefresh = false;
+        this.pendingForceRefresh = false;
         return;
       }
 
       if (this.inFlight) {
         this.pendingRefresh = true;
+        this.pendingForceRefresh = this.pendingForceRefresh || forceRefresh;
         return;
       }
 
       this.currentAsin = asin;
       this.inFlight = true;
       this.pendingRefresh = false;
+      this.pendingForceRefresh = false;
       window.UiDisplay.renderLoading(`https://sakura-checker.jp/search/${asin}/`);
       let latestAsin = asin;
 
@@ -47,6 +51,7 @@
         const response = await chrome.runtime.sendMessage({
           action: "checkSakuraScore",
           asin,
+          forceRefresh,
         });
 
         latestAsin = this.getCurrentPageAsin();
@@ -55,7 +60,14 @@
         }
 
         if (response && response.ok) {
-          window.UiDisplay.renderSuccess(response);
+          window.UiDisplay.renderSuccess(response, {
+            onRefresh:
+              response.cached
+                ? () => {
+                    this.refreshForCurrentPage({ forceRefresh: true });
+                  }
+                : null,
+          });
         } else {
           window.UiDisplay.renderError(response);
         }
@@ -78,12 +90,14 @@
         );
       } finally {
         this.inFlight = false;
+        const pendingForceRefresh = this.pendingForceRefresh;
         const shouldRetry =
           this.pendingRefresh &&
           (latestAsin !== asin || !document.getElementById("sakura-checker-result"));
         this.pendingRefresh = false;
+        this.pendingForceRefresh = false;
         if (shouldRetry) {
-          this.refreshForCurrentPage();
+          this.refreshForCurrentPage({ forceRefresh: pendingForceRefresh });
         }
       }
     }

--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -47,7 +47,17 @@
         display: flex;
         flex-direction: column;
         align-items: flex-end;
+        justify-content: flex-start;
         gap: 6px;
+      }
+
+      #${ROOT_ID} .sc-side-top,
+      #${ROOT_ID} .sc-side-bottom {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        flex-wrap: wrap;
       }
 
       #${ROOT_ID} .sc-score-value {
@@ -75,6 +85,7 @@
         line-height: 1;
         font-weight: 700;
         letter-spacing: -0.02em;
+        color: #e5374f;
       }
 
       #${ROOT_ID} .sc-suffix {
@@ -88,6 +99,7 @@
         align-items: center;
         gap: 8px;
         min-height: 28px;
+        margin-left: 1em;
       }
 
       #${ROOT_ID} .sc-verdict img {
@@ -97,16 +109,47 @@
       }
 
       #${ROOT_ID} .sc-verdict-text {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
         font-size: 13px;
         font-weight: 700;
         color: #565959;
         white-space: nowrap;
       }
 
+      #${ROOT_ID} .sc-accent {
+        color: #e5374f;
+      }
+
       #${ROOT_ID} .sc-status-value {
         color: #007185;
-        font-size: 13px;
+        font-size: 16px;
+        line-height: 1;
         white-space: nowrap;
+      }
+
+      #${ROOT_ID} .sc-status-indicator {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        font-size: 16px;
+      }
+
+      #${ROOT_ID} .sc-status-indicator[data-status-tone="fresh"] {
+        color: #067d62;
+      }
+
+      #${ROOT_ID} .sc-status-indicator[data-status-tone="cached"] {
+        color: #f0b400;
+      }
+
+      #${ROOT_ID} .sc-status-indicator[data-status-tone="error"] {
+        color: #e5374f;
       }
 
       #${ROOT_ID} .sc-link {
@@ -125,20 +168,32 @@
         justify-content: center;
       }
 
+      #${ROOT_ID} .sc-link.sc-link-button {
+        font-family: inherit;
+        line-height: 1.2;
+      }
+
+      #${ROOT_ID} .sc-link.sc-icon-link {
+        font-size: 16px;
+        line-height: 1;
+        border: 0;
+        background: transparent;
+        min-width: auto;
+        min-height: auto;
+        padding: 0;
+      }
+
+      #${ROOT_ID} .sc-link.sc-icon-link:hover {
+        background: transparent;
+        opacity: 0.7;
+      }
+
       #${ROOT_ID} .sc-link:hover {
         background: #f7fafa;
       }
 
-      #${ROOT_ID}[data-state="success"] .sc-status-value {
-        color: #067d62;
-      }
-
       #${ROOT_ID}[data-state="error"] {
         border-left-color: #b12704;
-      }
-
-      #${ROOT_ID}[data-state="error"] .sc-status-value {
-        color: #b12704;
       }
 
       #${ROOT_ID}[data-state="loading"] {
@@ -153,6 +208,11 @@
 
         #${ROOT_ID} .sc-side {
           align-items: flex-start;
+        }
+
+        #${ROOT_ID} .sc-side-top,
+        #${ROOT_ID} .sc-side-bottom {
+          justify-content: flex-start;
         }
       }
     `;
@@ -210,6 +270,27 @@
     return value;
   }
 
+  function createStatusIndicator(statusTone, currentLabel) {
+    const value = document.createElement("div");
+    value.className = "sc-value sc-status-value";
+
+    const indicator = document.createElement("span");
+    indicator.className = "sc-status-indicator";
+    indicator.dataset.statusTone = statusTone;
+    indicator.textContent = "●";
+
+    const tooltip =
+      `${currentLabel}\n` +
+      "緑: 取得成功した最新値\n" +
+      "黄: キャッシュから表示した値\n" +
+      "赤: 取得に失敗した値";
+    indicator.title = tooltip;
+    indicator.setAttribute("aria-label", currentLabel);
+
+    value.appendChild(indicator);
+    return value;
+  }
+
   function createVerdictNode(verdict) {
     if (!verdict || (!verdict.image && (!verdict.lines || !verdict.lines.length))) {
       return null;
@@ -228,11 +309,37 @@
     if (Array.isArray(verdict.lines) && verdict.lines.length) {
       const text = document.createElement("span");
       text.className = "sc-verdict-text";
-      text.textContent = verdict.lines.join(" / ");
+
+      verdict.lines.forEach((line) => {
+        text.appendChild(createVerdictLineNode(line));
+      });
+
       verdictNode.appendChild(text);
     }
 
     return verdictNode;
+  }
+
+  function createVerdictLineNode(line) {
+    const text = document.createElement("span");
+    const normalizedLine = String(line || "").trim();
+    const sakuraDegreeMatch = normalizedLine.match(/^サクラ度\s*(\d+(?:\.\d+)?%)$/);
+
+    if (!sakuraDegreeMatch) {
+      text.textContent = normalizedLine;
+      return text;
+    }
+
+    const label = document.createElement("span");
+    label.textContent = "🌸 ";
+    text.appendChild(label);
+
+    const value = document.createElement("span");
+    value.className = "sc-accent";
+    value.textContent = sakuraDegreeMatch[1];
+    text.appendChild(value);
+
+    return text;
   }
 
   function createScoreValue(score, verdict) {
@@ -297,17 +404,34 @@
     }
 
     const openLink = document.createElement("a");
-    openLink.className = "sc-link";
+    openLink.className = "sc-link sc-icon-link";
     openLink.href = sourceUrl;
     openLink.target = "_blank";
     openLink.rel = "noopener noreferrer";
-    openLink.textContent = "サクラチェッカーを開く";
+    openLink.title = "サクラチェッカーを開く";
+    openLink.setAttribute("aria-label", "サクラチェッカーを開く");
+    openLink.textContent = "🔗";
     value.appendChild(openLink);
 
     return value;
   }
 
-  function renderLayout({ score, verdict, sourceUrl, statusText }) {
+  function createRefreshButton(onRefresh) {
+    if (typeof onRefresh !== "function") {
+      return null;
+    }
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "sc-link sc-link-button";
+    button.textContent = "再取得";
+    button.addEventListener("click", () => {
+      onRefresh();
+    });
+    return button;
+  }
+
+  function renderLayout({ score, verdict, sourceUrl, statusNode = null, actionNode = null }) {
     const root = ensureRoot();
     clearRoot(root);
 
@@ -317,8 +441,26 @@
 
     const side = document.createElement("div");
     side.className = "sc-side";
-    appendItem(side, createTextValue(statusText, "sc-status-value"));
-    appendItem(side, createLinkValue(sourceUrl));
+
+    const sideTop = document.createElement("div");
+    sideTop.className = "sc-side-top";
+    if (statusNode) {
+      appendItem(sideTop, statusNode);
+    }
+
+    const sideBottom = document.createElement("div");
+    sideBottom.className = "sc-side-bottom";
+    if (actionNode) {
+      appendItem(sideBottom, actionNode);
+    }
+    appendItem(sideBottom, createLinkValue(sourceUrl));
+
+    if (sideTop.children.length) {
+      side.appendChild(sideTop);
+    }
+    if (sideBottom.children.length) {
+      side.appendChild(sideBottom);
+    }
 
     root.appendChild(main);
     root.appendChild(side);
@@ -331,18 +473,22 @@
       score: null,
       verdict: null,
       sourceUrl,
-      statusText: "取得中",
+      statusNode: createTextValue("取得中", "sc-status-value"),
     });
   }
 
-  function renderSuccess(payload) {
+  function renderSuccess(payload, { onRefresh = null } = {}) {
     const root = ensureRoot();
     root.dataset.state = "success";
     renderLayout({
       score: payload.score,
       verdict: payload.verdict || null,
       sourceUrl: payload.sourceUrl,
-      statusText: payload.cached ? "取得済み (キャッシュ)" : "取得済み",
+      statusNode: createStatusIndicator(
+        payload.cached ? "cached" : "fresh",
+        payload.cached ? "キャッシュから表示中" : "最新値を取得済み"
+      ),
+      actionNode: payload.cached ? createRefreshButton(onRefresh) : null,
     });
   }
 
@@ -353,7 +499,7 @@
       score: null,
       verdict: null,
       sourceUrl: payload && payload.sourceUrl ? payload.sourceUrl : null,
-      statusText: "取得失敗",
+      statusNode: createStatusIndicator("error", "取得失敗"),
     });
   }
 

--- a/content/ui-display.js
+++ b/content/ui-display.js
@@ -277,7 +277,7 @@
     const indicator = document.createElement("span");
     indicator.className = "sc-status-indicator";
     indicator.dataset.statusTone = statusTone;
-    indicator.textContent = "●";
+    indicator.textContent = getStatusSymbol(statusTone);
 
     const tooltip =
       `${currentLabel}\n` +
@@ -289,6 +289,18 @@
 
     value.appendChild(indicator);
     return value;
+  }
+
+  function getStatusSymbol(statusTone) {
+    if (statusTone === "fresh") {
+      return "✓";
+    }
+
+    if (statusTone === "error") {
+      return "×";
+    }
+
+    return "●";
   }
 
   function createVerdictNode(verdict) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
-    "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/content-flow.test.js",
+    "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",
     "test:live": "node --test --test-concurrency=1 tests/integration.test.js",
     "test:e2e-extension": "node scripts/run-extension-e2e.js",
     "test:browser-compare": "node scripts/run-browser-compare.js",

--- a/tests/background-flow.test.js
+++ b/tests/background-flow.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
 
-function loadBackgroundContext() {
+function loadBackgroundContext({ apiResult = { ok: true, cached: false } } = {}) {
   const listeners = {};
   const apiCalls = [];
 
@@ -27,7 +27,7 @@ function loadBackgroundContext() {
         },
         checkSakuraScore(options) {
           apiCalls.push(options);
-          return Promise.resolve({ ok: true, cached: false });
+          return Promise.resolve(apiResult);
         },
       },
       addEventListener() {},
@@ -73,4 +73,31 @@ test("background forwards forceRefresh requests to ApiClient", async () => {
   assert.equal(apiCalls[0].forceRefresh, true);
   assert.equal(responsePayload.ok, true);
   assert.equal(responsePayload.cached, false);
+});
+
+test("background defaults forceRefresh to false when omitted", async () => {
+  const { apiCalls, onMessage } = loadBackgroundContext({
+    apiResult: { ok: true, cached: true },
+  });
+  let responsePayload = null;
+
+  const keepChannelOpen = onMessage(
+    {
+      action: "checkSakuraScore",
+      asin: "B095JGJCC7",
+    },
+    null,
+    (payload) => {
+      responsePayload = payload;
+    }
+  );
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(keepChannelOpen, true);
+  assert.equal(apiCalls.length, 1);
+  assert.equal(apiCalls[0].asin, "B095JGJCC7");
+  assert.equal(apiCalls[0].forceRefresh, false);
+  assert.equal(responsePayload.ok, true);
+  assert.equal(responsePayload.cached, true);
 });

--- a/tests/background-flow.test.js
+++ b/tests/background-flow.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadBackgroundContext() {
+  const listeners = {};
+  const apiCalls = [];
+
+  const context = vm.createContext({
+    console,
+    importScripts: () => {},
+    chrome: {
+      runtime: {
+        onMessage: {
+          addListener(listener) {
+            listeners.onMessage = listener;
+          },
+        },
+      },
+    },
+    self: {
+      ApiClient: {
+        buildDetailUrl(asin) {
+          return `https://sakura-checker.jp/search/${asin}/`;
+        },
+        checkSakuraScore(options) {
+          apiCalls.push(options);
+          return Promise.resolve({ ok: true, cached: false });
+        },
+      },
+      addEventListener() {},
+      skipWaiting() {},
+      clients: {
+        claim() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+
+  const source = fs.readFileSync(path.join(__dirname, "..", "background.js"), "utf8");
+  vm.runInContext(source, context, { filename: "background.js" });
+
+  return {
+    apiCalls,
+    onMessage: listeners.onMessage,
+  };
+}
+
+test("background forwards forceRefresh requests to ApiClient", async () => {
+  const { apiCalls, onMessage } = loadBackgroundContext();
+  let responsePayload = null;
+
+  const keepChannelOpen = onMessage(
+    {
+      action: "checkSakuraScore",
+      asin: "B095JGJCC7",
+      forceRefresh: true,
+    },
+    null,
+    (payload) => {
+      responsePayload = payload;
+    }
+  );
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(keepChannelOpen, true);
+  assert.equal(apiCalls.length, 1);
+  assert.equal(apiCalls[0].asin, "B095JGJCC7");
+  assert.equal(apiCalls[0].forceRefresh, true);
+  assert.equal(responsePayload.ok, true);
+  assert.equal(responsePayload.cached, false);
+});

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -488,6 +488,119 @@ test("SakuraChecker renders a refresh button for cached results and refetches on
   assert.equal(refreshButton, null);
 });
 
+test("SakuraChecker preserves a pending force refresh while another refresh is in flight", async () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const sendMessageCalls = [];
+  const resolvers = [];
+  const chrome = {
+    runtime: {
+      sendMessage: async (payload) =>
+        new Promise((resolve) => {
+          sendMessageCalls.push(payload);
+          resolvers.push(resolve);
+        }),
+    },
+  };
+  const context = createExecutionContext({ document, chrome });
+
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+  loadScript(context, "content/ui-display.js");
+  loadScript(context, "content/sakura-checker.js");
+
+  let removePanelAfterSuccess = false;
+  const originalRenderSuccess = context.window.UiDisplay.renderSuccess;
+  context.window.UiDisplay.renderSuccess = (...args) => {
+    originalRenderSuccess(...args);
+    if (removePanelAfterSuccess) {
+      const root = document.getElementById("sakura-checker-result");
+      if (root) {
+        root.remove();
+      }
+    }
+  };
+
+  const initialRefreshPromise = context.window.SakuraChecker.refreshForCurrentPage();
+  assert.equal(sendMessageCalls.length, 1);
+  assert.equal(sendMessageCalls[0].forceRefresh, false);
+
+  resolvers.shift()({
+    ok: true,
+    cached: true,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  await initialRefreshPromise;
+
+  const cachedRoot = document.getElementById("sakura-checker-result");
+  const refreshButton = findFirstByTag(cachedRoot, "button");
+  assert.ok(refreshButton);
+
+  const overlappingRefreshPromise = context.window.SakuraChecker.refreshForCurrentPage();
+  assert.equal(sendMessageCalls.length, 2);
+  assert.equal(sendMessageCalls[1].forceRefresh, false);
+
+  refreshButton.dispatchEvent({ type: "click" });
+  removePanelAfterSuccess = true;
+
+  resolvers.shift()({
+    ok: true,
+    cached: true,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(sendMessageCalls.length, 3);
+  assert.equal(sendMessageCalls[2].forceRefresh, true);
+  removePanelAfterSuccess = false;
+
+  resolvers.shift()({
+    ok: true,
+    cached: false,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.70",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  await overlappingRefreshPromise;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const root = document.getElementById("sakura-checker-result");
+  const scoreText = findByClass(root, "sc-score-text");
+  const latestRefreshButton = findFirstByTag(root, "button");
+
+  assert.ok(root);
+  assert.equal(root.dataset.state, "success");
+  assert.ok(scoreText);
+  assert.equal(scoreText.textContent, "4.70");
+  assert.equal(latestRefreshButton, null);
+});
+
 test("UiDisplay renders the Sakura Checker link as an icon button", () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   const context = createExecutionContext({ document });

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -15,6 +15,7 @@ class FakeElement {
     this.textContent = "";
     this.className = "";
     this.id = "";
+    this.listeners = new Map();
   }
 
   appendChild(child) {
@@ -83,6 +84,26 @@ class FakeElement {
     }
 
     return this.attributes.get(name) || null;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatchEvent(event) {
+    const eventObject =
+      typeof event === "string"
+        ? { type: event }
+        : event && typeof event === "object"
+          ? event
+          : { type: "" };
+    const listeners = this.listeners.get(eventObject.type) || [];
+    for (const listener of listeners) {
+      listener.call(this, eventObject);
+    }
+    return true;
   }
 
   get firstChild() {
@@ -248,6 +269,10 @@ function findImages(root) {
   return images;
 }
 
+function findFirstByTag(root, tagName) {
+  return findFirst(root, (element) => element.tagName === String(tagName).toUpperCase());
+}
+
 function findByClass(root, className) {
   return findFirst(root, (element) =>
     String(element.className || "")
@@ -255,6 +280,33 @@ function findByClass(root, className) {
       .filter(Boolean)
       .includes(className)
   );
+}
+
+function findAllByClass(root, className) {
+  const matches = [];
+  walkTree(root, (element) => {
+    if (
+      String(element.className || "")
+        .split(/\s+/)
+        .filter(Boolean)
+        .includes(className)
+    ) {
+      matches.push(element);
+    }
+  });
+  return matches;
+}
+
+function getNodeText(node) {
+  let value = String(node.textContent || "");
+  for (const child of node.children || []) {
+    value += getNodeText(child);
+  }
+  return value;
+}
+
+function getChildNodeTexts(node) {
+  return (node.children || []).map((child) => getNodeText(child));
 }
 
 test("content.js initializes SakuraChecker immediately after document_end", () => {
@@ -382,6 +434,180 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(images[2].src, "https://sakura-checker.jp/images/rv_level03.png");
 });
 
+test("SakuraChecker renders a refresh button for cached results and refetches on click", async () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const sendMessageCalls = [];
+  const chrome = {
+    runtime: {
+      sendMessage: async (payload) => {
+        sendMessageCalls.push(payload);
+
+        return {
+          ok: true,
+          cached: payload.forceRefresh !== true,
+          sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+          score: {
+            kind: "text",
+            value: payload.forceRefresh === true ? "4.70" : "4.29",
+            suffix: "/5",
+          },
+          verdict: {
+            kind: "text-verdict",
+            lines: ["安全", "サクラ度 0%"],
+          },
+        };
+      },
+    },
+  };
+  const context = createExecutionContext({ document, chrome });
+
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+  loadScript(context, "content/ui-display.js");
+  loadScript(context, "content/sakura-checker.js");
+
+  await context.window.SakuraChecker.refreshForCurrentPage();
+
+  let root = document.getElementById("sakura-checker-result");
+  let refreshButton = findFirstByTag(root, "button");
+  assert.ok(refreshButton);
+  assert.equal(sendMessageCalls.length, 1);
+  assert.equal(sendMessageCalls[0].forceRefresh, false);
+
+  await refreshButton.dispatchEvent({ type: "click" });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  root = document.getElementById("sakura-checker-result");
+  refreshButton = findFirstByTag(root, "button");
+  const scoreText = findByClass(root, "sc-score-text");
+
+  assert.equal(sendMessageCalls.length, 2);
+  assert.equal(sendMessageCalls[1].forceRefresh, true);
+  assert.ok(scoreText);
+  assert.equal(scoreText.textContent, "4.70");
+  assert.equal(refreshButton, null);
+});
+
+test("UiDisplay renders the Sakura Checker link as an icon button", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess({
+    ok: true,
+    cached: true,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  const link = findFirst(root, (element) => element.tagName === "A");
+
+  assert.ok(link);
+  assert.equal(link.textContent, "🔗");
+  assert.equal(link.className, "sc-link sc-icon-link");
+  assert.equal(link.getAttribute("aria-label"), "サクラチェッカーを開く");
+  assert.equal(link.title, "サクラチェッカーを開く");
+});
+
+test("UiDisplay renders a cached-status indicator with tooltip guidance", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess({
+    ok: true,
+    cached: true,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  const indicator = findByClass(root, "sc-status-indicator");
+
+  assert.ok(indicator);
+  assert.equal(indicator.textContent, "●");
+  assert.equal(indicator.dataset.statusTone, "cached");
+  assert.equal(indicator.getAttribute("aria-label"), "キャッシュから表示中");
+  assert.match(indicator.title, /緑: 取得成功した最新値/);
+  assert.match(indicator.title, /黄: キャッシュから表示した値/);
+  assert.match(indicator.title, /赤: 取得に失敗した値/);
+});
+
+test("UiDisplay places the status dot above right-aligned action buttons", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess(
+    {
+      ok: true,
+      cached: true,
+      sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+      score: {
+        kind: "text",
+        value: "4.29",
+        suffix: "/5",
+      },
+      verdict: {
+        kind: "text-verdict",
+        lines: ["合格", "サクラ度 0%"],
+      },
+    },
+    { onRefresh: () => {} }
+  );
+
+  const root = document.getElementById("sakura-checker-result");
+  const side = findByClass(root, "sc-side");
+  const top = findByClass(side, "sc-side-top");
+  const bottom = findByClass(side, "sc-side-bottom");
+
+  assert.ok(side);
+  assert.ok(top);
+  assert.ok(bottom);
+  assert.equal(side.children[0], top);
+  assert.equal(side.children[1], bottom);
+  assert.ok(findByClass(top, "sc-status-indicator"));
+  assert.ok(findFirstByTag(bottom, "button"));
+  assert.ok(findFirst(bottom, (element) => element.tagName === "A"));
+});
+
+test("UiDisplay renders an error-status indicator in red", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderError({
+    ok: false,
+    code: "network_error",
+    message: "Failed to fetch",
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  const indicator = findByClass(root, "sc-status-indicator");
+
+  assert.ok(indicator);
+  assert.equal(indicator.dataset.statusTone, "error");
+  assert.equal(indicator.getAttribute("aria-label"), "取得失敗");
+});
+
 test("SakuraChecker keeps the first response when the URL changes to the same ASIN during fetch", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/gp/product/B095JGJCC7");
   const sendMessageCalls = [];
@@ -467,7 +693,41 @@ test("UiDisplay renders text-based itemsearch scores", () => {
 
   const verdictText = findByClass(root, "sc-verdict-text");
   assert.ok(verdictText);
-  assert.equal(verdictText.textContent, "危険 / サクラ度 90%");
+  assert.deepEqual(getChildNodeTexts(verdictText), ["危険", "🌸 90%"]);
+});
+
+test("UiDisplay highlights score and sakura percentage with the accent color", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess({
+    ok: true,
+    cached: true,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  const style = document.getElementById("sakura-checker-style");
+  const accentNodes = findAllByClass(root, "sc-accent");
+  const verdictText = findByClass(root, "sc-verdict-text");
+
+  assert.ok(style);
+  assert.match(style.textContent, /\.sc-score-text\s*\{[\s\S]*color: #e5374f;/);
+  assert.match(style.textContent, /\.sc-accent\s*\{[\s\S]*color: #e5374f;/);
+  assert.equal(accentNodes.length, 1);
+  assert.equal(accentNodes[0].textContent, "0%");
+  assert.ok(verdictText);
+  assert.deepEqual(getChildNodeTexts(verdictText), ["合格", "🌸 0%"]);
 });
 
 test("SakuraChecker does not render or fetch on non-product pages that contain search-result ASINs", async () => {

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -550,6 +550,34 @@ test("UiDisplay renders a cached-status indicator with tooltip guidance", () => 
   assert.match(indicator.title, /赤: 取得に失敗した値/);
 });
 
+test("UiDisplay renders a fresh-status indicator as a checkmark", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const context = createExecutionContext({ document });
+  loadScript(context, "content/ui-display.js");
+
+  context.window.UiDisplay.renderSuccess({
+    ok: true,
+    cached: false,
+    sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+    score: {
+      kind: "text",
+      value: "4.29",
+      suffix: "/5",
+    },
+    verdict: {
+      kind: "text-verdict",
+      lines: ["合格", "サクラ度 0%"],
+    },
+  });
+
+  const root = document.getElementById("sakura-checker-result");
+  const indicator = findByClass(root, "sc-status-indicator");
+
+  assert.ok(indicator);
+  assert.equal(indicator.textContent, "✓");
+  assert.equal(indicator.dataset.statusTone, "fresh");
+});
+
 test("UiDisplay places the status dot above right-aligned action buttons", () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   const context = createExecutionContext({ document });
@@ -604,6 +632,7 @@ test("UiDisplay renders an error-status indicator in red", () => {
   const indicator = findByClass(root, "sc-status-indicator");
 
   assert.ok(indicator);
+  assert.equal(indicator.textContent, "×");
   assert.equal(indicator.dataset.statusTone, "error");
   assert.equal(indicator.getAttribute("aria-label"), "取得失敗");
 });


### PR DESCRIPTION
## Summary
- add an explicit refresh action for cached Sakura Checker results and pass force-refresh through the background worker
- compact the panel UI with icon-only outbound link, status dot states, and updated score/verdict styling
- bump the patch version to 2.1.3 and add coverage for background and content flows

## Testing
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **キャッシュ結果の強制リフレッシュ機能を追加した / ユーザーが明示的にキャッシュされたデータを更新できるようにするため**
  - `forceRefresh`フラグをメッセージハンドラーで処理し、バックグラウンド・ワーカーから API に転送

- **スコアパネルの UI をコンパクト化：リンクをアイコン表示、ステータスドット追加、スコア・判定文のスタイル更新 / パネルの表示領域を効率化し、ユーザーがデータ取得状態を一目で判断できるようにするため**
  - リンクを「🔗」アイコンのみに、ステータス表示に「●」ドット（fresh/cached/error 状態）を追加、判定文に Sakura 度を色付け表示

- **リフレッシュボタンをキャッシュ結果にのみ表示 / 既にキャッシュされたデータのみ更新対象にするため**
  - キャッシュ済み結果に対して「再取得」ボタンを表示し、クリック時に `forceRefresh: true` で再取得を実行

- **バージョンを 2.1.2 から 2.1.3 にバンプ / 機能追加と UI 変更をリリースするため**

- **バックグラウンド・コンテンツフロー用のテストスイートを追加 / forceRefresh フラグが正しく伝播し、UI が期待通り動作することを保証するため**
  - `background-flow.test.js` と `content-flow.test.js` を拡張し、メッセージハンドリングと UI レンダリングの動作を検証

<!-- end of auto-generated comment: release notes by coderabbit.ai -->