### PR TITLE
Shorten rendered-score wait after tab load

### DIFF
--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -25,8 +25,12 @@
   }
 
   function resolveTimeoutMs(value, fallback) {
+    if (value === undefined || value === null) {
+      return fallback;
+    }
+
     const resolved = Number(value);
-    return Number.isFinite(resolved) && resolved > 0 ? resolved : fallback;
+    return Number.isFinite(resolved) ? Math.max(0, resolved) : fallback;
   }
 
   function tabsCreate(createProperties) {
@@ -507,13 +511,15 @@
       if (typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()) {
         await submitProductUrlSearch(tab.id, urlSearchProductUrl, effectiveLoadTimeoutMs);
       }
+      const renderDeadline = Date.now() + effectiveRenderTimeoutMs;
       await injectParserWithRetry(tab.id, {
         timeoutMs: effectiveRenderTimeoutMs,
         pollIntervalMs,
       });
+      const remainingRenderTimeoutMs = Math.max(0, renderDeadline - Date.now());
       return await pollExtractedScore(tab.id, {
         asin,
-        timeoutMs: effectiveRenderTimeoutMs,
+        timeoutMs: remainingRenderTimeoutMs,
         pollIntervalMs,
       });
     } finally {

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -5,7 +5,8 @@
   }
   root.RenderedScoreClient = exportsObject;
 })(typeof self !== "undefined" ? self : globalThis, function () {
-  const DEFAULT_TIMEOUT_MS = 15000;
+  const DEFAULT_TAB_TIMEOUT_MS = 15000;
+  const DEFAULT_RENDER_TIMEOUT_MS = 3000;
   const DEFAULT_POLL_INTERVAL_MS = 250;
   const PARSER_SCRIPT_FILE = "background/rendered-score-parser.js";
 
@@ -21,6 +22,11 @@
     }
 
     return new Error(defaultMessage);
+  }
+
+  function resolveTimeoutMs(value, fallback) {
+    const resolved = Number(value);
+    return Number.isFinite(resolved) && resolved > 0 ? resolved : fallback;
   }
 
   function tabsCreate(createProperties) {
@@ -130,7 +136,7 @@
   }
 
   async function injectParserWithRetry(tabId, options = {}) {
-    const timeoutMs = Number(options.timeoutMs || DEFAULT_TIMEOUT_MS);
+    const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_RENDER_TIMEOUT_MS);
     const pollIntervalMs = Number(options.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS);
     const startedAt = Date.now();
     let lastError = null;
@@ -232,7 +238,7 @@
     });
   }
 
-  function waitForTabReload(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  function waitForTabReload(tabId, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
     let cleanup = () => {};
 
     const promise = new Promise((resolve, reject) => {
@@ -294,7 +300,7 @@
     };
   }
 
-  async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
     const reloadHandle = waitForTabReload(tabId, timeoutMs);
     let submissionResult = null;
 
@@ -361,7 +367,7 @@
     await reloadHandle.promise;
   }
 
-  function waitForTabComplete(tabId, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  function waitForTabComplete(tabId, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
       if (
         typeof chrome === "undefined" ||
@@ -426,7 +432,7 @@
   }
 
   async function pollExtractedScore(tabId, options = {}) {
-    const timeoutMs = Number(options.timeoutMs || DEFAULT_TIMEOUT_MS);
+    const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_RENDER_TIMEOUT_MS);
     const pollIntervalMs = Number(options.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS);
     const asin = options.asin || null;
     const startedAt = Date.now();
@@ -476,10 +482,20 @@
     asin,
     sourceUrl,
     timeoutMs,
+    loadTimeoutMs,
+    renderTimeoutMs,
     pollIntervalMs,
     urlSearchProductUrl,
   }) {
     let tab = null;
+    const effectiveLoadTimeoutMs = resolveTimeoutMs(
+      loadTimeoutMs,
+      resolveTimeoutMs(timeoutMs, DEFAULT_TAB_TIMEOUT_MS)
+    );
+    const effectiveRenderTimeoutMs = resolveTimeoutMs(
+      renderTimeoutMs,
+      resolveTimeoutMs(timeoutMs, DEFAULT_RENDER_TIMEOUT_MS)
+    );
 
     try {
       tab = await tabsCreate({
@@ -487,17 +503,17 @@
         active: false,
       });
 
-      await waitForTabComplete(tab.id, timeoutMs);
+      await waitForTabComplete(tab.id, effectiveLoadTimeoutMs);
       if (typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()) {
-        await submitProductUrlSearch(tab.id, urlSearchProductUrl, timeoutMs);
+        await submitProductUrlSearch(tab.id, urlSearchProductUrl, effectiveLoadTimeoutMs);
       }
       await injectParserWithRetry(tab.id, {
-        timeoutMs,
+        timeoutMs: effectiveRenderTimeoutMs,
         pollIntervalMs,
       });
       return await pollExtractedScore(tab.id, {
         asin,
-        timeoutMs,
+        timeoutMs: effectiveRenderTimeoutMs,
         pollIntervalMs,
       });
     } finally {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -293,6 +293,49 @@ test("fetchRenderedScore retries transient parser injection failures before poll
   }
 });
 
+test("fetchRenderedScore uses the remaining render timeout after parser injection retries", async () => {
+  const stub = installChromeStub({
+    parserInjectionResponder(_details, callCount) {
+      if (callCount === 1) {
+        return "The tab is still navigating.";
+      }
+
+      return null;
+    },
+    scriptResponder() {
+      throw new Error("Polling should not start after the render deadline is exhausted.");
+    },
+  });
+  const originalDateNow = Date.now;
+  const nowValues = [1000, 1000, 1000, 1009, 1010, 1010, 1010];
+  let lastNowValue = nowValues[0];
+  Date.now = () => {
+    if (nowValues.length > 0) {
+      lastNowValue = nowValues.shift();
+    }
+
+    return lastNowValue;
+  };
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B095JGJCC7",
+      sourceUrl: "https://sakura-checker.jp/search/B095JGJCC7/",
+      timeoutMs: 200,
+      renderTimeoutMs: 10,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "parse_error");
+    assert.equal(stub.parserInjectionCalls, 2);
+    assert.equal(stub.extractCalls, 0);
+  } finally {
+    Date.now = originalDateNow;
+    stub.cleanup();
+  }
+});
+
 test("fetchRenderedScore closes the temporary tab after a render timeout", async () => {
   const stub = installChromeStub({
     scriptResponder() {


### PR DESCRIPTION
## Summary
- split the temporary tab timeout into page-load and rendered-score phases
- keep tab load and URL-search reload waits at 15 seconds
- shorten parser injection and rendered score polling to 3 seconds after the tab finishes loading

## Validation
- node --test tests/rendered-score-client.test.js tests/api-client.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- タイムアウト定数を2つに分割：ページロード関連に `DEFAULT_TAB_TIMEOUT_MS` (15秒)、パーサー挿入とスコアポーリング関連に `DEFAULT_RENDER_TIMEOUT_MS` (3秒) を使用することで、ページ読み込み後のレンダリング完了待ちを短縮できるようにした。

- `resolveTimeoutMs` 関数を追加：呼び出し側から指定されたタイムアウト値を正規化し、無効な値には默认値を使用する仕組みにして、多様な入力値に対応できるようにした。

- `fetchRenderedScore` 関数に `loadTimeoutMs` と `renderTimeoutMs` パラメータを追加：フェーズごとに異なるタイムアウト値を指定できるようにして、ページロード時間とレンダリング時間を独立制御できるようにした。

- ページロード関連の処理（`waitForTabComplete`、`submitProductUrlSearch`）に `effectiveLoadTimeoutMs` を、レンダリング関連の処理（`injectParserWithRetry`、`pollExtractedScore`）に `effectiveRenderTimeoutMs` を適用：フェーズごとに適切なタイムアウトを割り当てるようにした。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->