### PR TITLE
Ignore unsupported Prime Video pages and bump version to 2.1.4

### DIFF
--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -12,7 +12,10 @@
   }
 
   function isUnsupportedSectionPath(pathname) {
-    return UNSUPPORTED_SECTION_PATTERNS.some((pattern) => pattern.test(String(pathname || "")));
+    const normalizedPathname = String(pathname || "").replace(/^\/-\/[^/]+(?=\/|$)/i, "");
+    return UNSUPPORTED_SECTION_PATTERNS.some((pattern) =>
+      pattern.test(String(normalizedPathname || ""))
+    );
   }
 
   function extractProductASIN() {

--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -1,11 +1,25 @@
 (function () {
   const asinUtils = window.AsinUtils;
+  const UNSUPPORTED_SECTION_PATTERNS = [
+    /^\/gp\/video(?:\/|$)/i,
+    /^\/(?:prime-video|Prime-Video)(?:\/|$)/i,
+    /^\/music(?:\/|$)/i,
+    /^\/gp\/dmusic(?:\/|$)/i,
+  ];
 
   if (!asinUtils) {
     throw new Error("AsinUtils is not available.");
   }
 
+  function isUnsupportedSectionPath(pathname) {
+    return UNSUPPORTED_SECTION_PATTERNS.some((pattern) => pattern.test(String(pathname || "")));
+  }
+
   function extractProductASIN() {
+    if (isUnsupportedSectionPath(window.location.pathname)) {
+      return null;
+    }
+
     const pathAsin = asinUtils.extractAsinFromPath(window.location.pathname);
     if (pathAsin) {
       return pathAsin;

--- a/content/asin-extractor.js
+++ b/content/asin-extractor.js
@@ -3,7 +3,7 @@
   const UNSUPPORTED_SECTION_PATTERNS = [
     /^\/gp\/video(?:\/|$)/i,
     /^\/(?:prime-video|Prime-Video)(?:\/|$)/i,
-    /^\/music(?:\/|$)/i,
+    /^\/music\/player(?:\/|$)/i,
     /^\/gp\/dmusic(?:\/|$)/i,
   ];
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -376,6 +376,34 @@ test("AsinExtractor reads the canonical product URL when pathname is not a produ
   assert.equal(context.window.AsinExtractor.isProductPage(), true);
 });
 
+test("AsinExtractor ignores Prime Video and music pages even when canonical has a product ASIN", () => {
+  const primeVideoDocument = createPageDocument("https://www.amazon.co.jp/gp/video/detail/B0PRIME123");
+  const primeCanonical = primeVideoDocument.createElement("link");
+  primeCanonical.setAttribute("rel", "canonical");
+  primeCanonical.setAttribute("href", "https://www.amazon.co.jp/dp/B095JGJCC7");
+  primeVideoDocument.head.appendChild(primeCanonical);
+
+  let context = createExecutionContext({ document: primeVideoDocument });
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
+  assert.equal(context.window.AsinExtractor.isProductPage(), false);
+
+  const musicDocument = createPageDocument("https://www.amazon.co.jp/music/player/albums/B0MUSIC1234");
+  const musicCanonical = musicDocument.createElement("link");
+  musicCanonical.setAttribute("rel", "canonical");
+  musicCanonical.setAttribute("href", "https://www.amazon.co.jp/dp/B091BGMKYS");
+  musicDocument.head.appendChild(musicCanonical);
+
+  context = createExecutionContext({ document: musicDocument });
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
+  assert.equal(context.window.AsinExtractor.isProductPage(), false);
+});
+
 test("SakuraChecker refresh shows loading first and then renders fetched score images", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   let resolveResponse = null;
@@ -877,6 +905,35 @@ test("SakuraChecker does not render or fetch on non-product pages that contain s
   const searchResult = document.createElement("div");
   searchResult.setAttribute("data-asin", "B095JGJCC7");
   document.body.appendChild(searchResult);
+
+  let sendMessageCalled = false;
+  const chrome = {
+    runtime: {
+      sendMessage: async () => {
+        sendMessageCalled = true;
+        return { ok: true };
+      },
+    },
+  };
+  const context = createExecutionContext({ document, chrome });
+
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+  loadScript(context, "content/ui-display.js");
+  loadScript(context, "content/sakura-checker.js");
+
+  await context.window.SakuraChecker.refreshForCurrentPage();
+
+  assert.equal(sendMessageCalled, false);
+  assert.equal(document.getElementById("sakura-checker-result"), null);
+});
+
+test("SakuraChecker does not render or fetch on unsupported Prime Video pages", async () => {
+  const document = createPageDocument("https://www.amazon.co.jp/gp/video/detail/B0PRIME123");
+  const canonical = document.createElement("link");
+  canonical.setAttribute("rel", "canonical");
+  canonical.setAttribute("href", "https://www.amazon.co.jp/dp/B095JGJCC7");
+  document.head.appendChild(canonical);
 
   let sendMessageCalled = false;
   const chrome = {

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -404,6 +404,16 @@ test("AsinExtractor ignores Prime Video and music pages even when canonical has 
   assert.equal(context.window.AsinExtractor.isProductPage(), false);
 });
 
+test("AsinExtractor still detects standard product URLs under the music section", () => {
+  const document = createPageDocument("https://www.amazon.co.jp/music/dp/B091BGMKYS");
+  const context = createExecutionContext({ document });
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), "B091BGMKYS");
+  assert.equal(context.window.AsinExtractor.isProductPage(), true);
+});
+
 test("SakuraChecker refresh shows loading first and then renders fetched score images", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
   let resolveResponse = null;

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -390,6 +390,21 @@ test("AsinExtractor ignores Prime Video and music pages even when canonical has 
   assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
   assert.equal(context.window.AsinExtractor.isProductPage(), false);
 
+  const localePrimeVideoDocument = createPageDocument(
+    "https://www.amazon.co.jp/-/en/gp/video/detail/B0PRIME123"
+  );
+  const localePrimeCanonical = localePrimeVideoDocument.createElement("link");
+  localePrimeCanonical.setAttribute("rel", "canonical");
+  localePrimeCanonical.setAttribute("href", "https://www.amazon.co.jp/dp/B095JGJCC7");
+  localePrimeVideoDocument.head.appendChild(localePrimeCanonical);
+
+  context = createExecutionContext({ document: localePrimeVideoDocument });
+  loadScript(context, "shared/asin-utils.js");
+  loadScript(context, "content/asin-extractor.js");
+
+  assert.equal(context.window.AsinExtractor.extractProductASIN(), null);
+  assert.equal(context.window.AsinExtractor.isProductPage(), false);
+
   const musicDocument = createPageDocument("https://www.amazon.co.jp/music/player/albums/B0MUSIC1234");
   const musicCanonical = musicDocument.createElement("link");
   musicCanonical.setAttribute("rel", "canonical");


### PR DESCRIPTION
## Summary
- ignore Prime Video and Amazon Music section URLs before attempting ASIN extraction
- add content-flow coverage to ensure unsupported pages do not fetch or render Sakura Checker results
- bump extension version to 2.1.4 and sync manifest/package metadata

## Validation
- node --test tests/content-flow.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Prime VideoおよびAmazon Musicページの検出機能を追加した** / 対応していないセクションURLから不正なASIN抽出を防ぐため

- **未対応ページではASIN抽出と商品ページ判定をスキップするように変更した** / これらのページではSakura Checkerの表示・通信が発生しないようにするため

- **未対応ページの処理を検証するテストケースを追加した** / Prime VideoやAmazon Musicページで正しく動作することを確認するため

- **拡張機能のバージョンを2.1.3から2.1.4に更新した** / 新機能追加に伴うバージョン管理のため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->