### PR TITLE
Add Sakura Checker fallback search for unresolved ASINs

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,6 +11,8 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   self.ApiClient.checkSakuraScore({
     asin: request.asin,
     forceRefresh: request.forceRefresh === true,
+    productTitle: request.productTitle,
+    productUrl: request.productUrl,
   })
     .then((result) => sendResponse(result))
     .catch((error) => {

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -56,6 +56,14 @@
     return String(value || "").replace(/\s+/g, " ").trim();
   }
 
+  function buildInFlightRequestKey({ asin, productTitle, productUrl }) {
+    return JSON.stringify({
+      asin: String(asin || ""),
+      productTitle: normalizeSearchWord(productTitle),
+      productUrl: normalizeSearchWord(productUrl),
+    });
+  }
+
   function resolveSakuraUrl(value) {
     if (!value) {
       return value;
@@ -431,9 +439,14 @@
       typeof fetchRenderedScoreImpl === "function"
         ? fetchRenderedScoreImpl
         : RenderedScoreClient.fetchRenderedScore;
+    const requestKey = buildInFlightRequestKey({
+      asin,
+      productTitle,
+      productUrl,
+    });
 
-    if (inFlightRequests.has(asin)) {
-      return inFlightRequests.get(asin);
+    if (inFlightRequests.has(requestKey)) {
+      return inFlightRequests.get(requestKey);
     }
 
     const requestPromise = requestCoordinator
@@ -449,12 +462,12 @@
         })
       )
       .finally(() => {
-        if (inFlightRequests.get(asin) === requestPromise) {
-          inFlightRequests.delete(asin);
+        if (inFlightRequests.get(requestKey) === requestPromise) {
+          inFlightRequests.delete(requestKey);
         }
       });
 
-    inFlightRequests.set(asin, requestPromise);
+    inFlightRequests.set(requestKey, requestPromise);
     return requestPromise;
   }
 

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -295,16 +295,22 @@
     return Boolean(renderedResult && renderedResult.code === "url_search_required");
   }
 
+  // Only explicit failures should consult backup retry codes; anything else
+  // either succeeded already or is ambiguous enough to warrant one backup try.
   function shouldRetryWithBackupSearch(renderedResult) {
     if (hasValidSuccessPayload(renderedResult)) {
       return false;
     }
 
-    if (!renderedResult || renderedResult.ok !== false) {
+    if (!renderedResult) {
       return true;
     }
 
-    return BACKUP_ERROR_CODES.has(renderedResult.code);
+    if (renderedResult.ok === false) {
+      return BACKUP_ERROR_CODES.has(renderedResult.code);
+    }
+
+    return false;
   }
 
   async function attemptRenderedFetch(fetchRenderedScore, options, sourceUrl) {

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -15,6 +15,14 @@
   const CACHE_PREFIX = "score:";
   const MIN_REQUEST_INTERVAL_MS = 2000;
   const MAX_REQUEST_JITTER_MS = 250;
+  const SAKURA_HOME_URL = "https://sakura-checker.jp/";
+  const BACKUP_ERROR_CODES = new Set([
+    "not_found",
+    "not_ready",
+    "not_available",
+    "parse_error",
+    "url_search_required",
+  ]);
 
   function encodeItemSearchWord(value) {
     const normalizedValue = String(value || "");
@@ -36,8 +44,16 @@
     return `https://sakura-checker.jp/search/${asin}/`;
   }
 
+  function buildHomeUrl() {
+    return SAKURA_HOME_URL;
+  }
+
   function buildAmazonProductUrl(asin) {
     return `https://www.amazon.co.jp/dp/${encodeURIComponent(String(asin || ""))}`;
+  }
+
+  function normalizeSearchWord(value) {
+    return String(value || "").replace(/\s+/g, " ").trim();
   }
 
   function resolveSakuraUrl(value) {
@@ -279,8 +295,34 @@
     return Boolean(renderedResult && renderedResult.code === "url_search_required");
   }
 
+  function shouldRetryWithBackupSearch(renderedResult) {
+    if (hasValidSuccessPayload(renderedResult)) {
+      return false;
+    }
+
+    if (!renderedResult || renderedResult.ok !== false) {
+      return true;
+    }
+
+    return BACKUP_ERROR_CODES.has(renderedResult.code);
+  }
+
+  async function attemptRenderedFetch(fetchRenderedScore, options, sourceUrl) {
+    try {
+      return await fetchRenderedScore(options);
+    } catch (error) {
+      return createFailure(
+        "network_error",
+        error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
+        sourceUrl
+      );
+    }
+  }
+
   async function fetchFreshScore({
     asin,
+    productTitle,
+    productUrl,
     fetchRenderedScore,
     nowImpl,
     randomImpl,
@@ -288,6 +330,8 @@
   }) {
     const requestUrl = buildSourceUrl(asin);
     const sourceUrl = buildDetailUrl(asin);
+    const normalizedProductTitle = normalizeSearchWord(productTitle);
+    const normalizedProductUrl = normalizeSearchWord(productUrl);
     let renderedResult = null;
 
     await requestCoordinator.waitForTurn({
@@ -296,33 +340,41 @@
       randomImpl,
     });
 
-    try {
-      renderedResult = await fetchRenderedScore({
+    renderedResult = await attemptRenderedFetch(
+      fetchRenderedScore,
+      {
         asin,
         sourceUrl: requestUrl,
-      });
-    } catch (error) {
-      return createFailure(
-        "network_error",
-        error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
+      },
+      sourceUrl
+    );
+
+    if (shouldRetryWithBackupSearch(renderedResult) && normalizedProductTitle) {
+      renderedResult = await attemptRenderedFetch(
+        fetchRenderedScore,
+        {
+          asin,
+          sourceUrl: buildHomeUrl(),
+          searchWord: normalizedProductTitle,
+        },
         sourceUrl
       );
     }
 
-    if (shouldRetryWithProductUrl(renderedResult)) {
-      try {
-        renderedResult = await fetchRenderedScore({
+    if (
+      shouldRetryWithProductUrl(renderedResult) ||
+      (shouldRetryWithBackupSearch(renderedResult) &&
+        (normalizedProductUrl || normalizedProductTitle))
+    ) {
+      renderedResult = await attemptRenderedFetch(
+        fetchRenderedScore,
+        {
           asin,
           sourceUrl,
-          urlSearchProductUrl: buildAmazonProductUrl(asin),
-        });
-      } catch (error) {
-        return createFailure(
-          "network_error",
-          error instanceof Error ? error.message : "Failed to inspect Sakura Checker.",
-          sourceUrl
-        );
-      }
+          urlSearchProductUrl: normalizedProductUrl || buildAmazonProductUrl(asin),
+        },
+        sourceUrl
+      );
     }
 
     if (!renderedResult || !renderedResult.ok) {
@@ -345,6 +397,8 @@
   async function checkSakuraScore({
     asin,
     forceRefresh = false,
+    productTitle,
+    productUrl,
     fetchRenderedScoreImpl,
     nowImpl,
     randomImpl,
@@ -380,6 +434,8 @@
       .enqueue(() =>
         fetchFreshScore({
           asin,
+          productTitle,
+          productUrl,
           fetchRenderedScore,
           nowImpl,
           randomImpl,
@@ -399,6 +455,7 @@
   return {
     buildAmazonProductUrl,
     buildDetailUrl,
+    buildHomeUrl,
     buildSourceUrl,
     checkSakuraScore,
     encodeItemSearchWord,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -304,14 +304,14 @@
     };
   }
 
-  async function submitProductUrlSearch(tabId, amazonProductUrl, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
+  async function submitSearch(tabId, searchWord, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
     const reloadHandle = waitForTabReload(tabId, timeoutMs);
     let submissionResult = null;
 
     try {
       submissionResult = await executeTabFunction(
         tabId,
-        (productUrl) => {
+        (submittedSearchWord) => {
           const input = document.querySelector("#urlsearchForm");
           if (!input) {
             return {
@@ -320,8 +320,8 @@
             };
           }
 
-          input.value = productUrl;
-          input.setAttribute("value", productUrl);
+          input.value = submittedSearchWord;
+          input.setAttribute("value", submittedSearchWord);
 
           if (typeof self.setactionsearchForm === "function") {
             self.setactionsearchForm(true);
@@ -351,8 +351,8 @@
             message: "The Sakura Checker search form could not be submitted.",
           };
         },
-        [amazonProductUrl],
-        "Failed to submit the Sakura Checker URL search."
+        [searchWord],
+        "Failed to submit the Sakura Checker search."
       );
     } catch (error) {
       reloadHandle.cancel();
@@ -364,7 +364,7 @@
       throw new Error(
         submissionResult && submissionResult.message
           ? submissionResult.message
-          : "Could not submit the Sakura Checker URL search."
+          : "Could not submit the Sakura Checker search."
       );
     }
 
@@ -489,6 +489,7 @@
     loadTimeoutMs,
     renderTimeoutMs,
     pollIntervalMs,
+    searchWord,
     urlSearchProductUrl,
   }) {
     let tab = null;
@@ -508,8 +509,14 @@
       });
 
       await waitForTabComplete(tab.id, effectiveLoadTimeoutMs);
-      if (typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()) {
-        await submitProductUrlSearch(tab.id, urlSearchProductUrl, effectiveLoadTimeoutMs);
+      const submittedSearchWord =
+        typeof searchWord === "string" && searchWord.trim()
+          ? searchWord.trim()
+          : typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()
+            ? urlSearchProductUrl.trim()
+            : "";
+      if (submittedSearchWord) {
+        await submitSearch(tab.id, submittedSearchWord, effectiveLoadTimeoutMs);
       }
       const renderDeadline = Date.now() + effectiveRenderTimeoutMs;
       await injectParserWithRetry(tab.id, {

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -479,6 +479,23 @@
     const scoreText = normalizeText((scoreNode || {}).textContent || "");
     const scoreMatch = scoreText.match(/([0-9]+(?:\.[0-9]+)?)\s*\/\s*5/i);
     if (!scoreMatch) {
+      const detailLink = Array.from(matchingCandidate.querySelectorAll("a[href]")).find((anchor) => {
+        const href = String(anchor.getAttribute("href") || anchor.href || "");
+        if (!href || !/\/search\//i.test(href)) {
+          return false;
+        }
+
+        return !context.requestedAsinPattern || context.requestedAsinPattern.test(href);
+      });
+
+      if (detailLink) {
+        return createFailure(
+          "url_search_required",
+          "Sakura Checker requires opening the product detail page for this itemsearch result.",
+          false
+        );
+      }
+
       return null;
     }
 
@@ -632,7 +649,7 @@
 
   function buildFallbackResult(context) {
     const hasLoadingSignals = Boolean(
-      context.root.querySelector(".loader, .loading, .item-review-wrap, .sakuraBlock, #pagetop")
+      context.root.querySelector(".loader, .loading, .item-review-wrap, .sakuraBlock")
     );
 
     return createFailure(

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -20,6 +20,23 @@
       return window.AsinExtractor.extractProductASIN();
     }
 
+    getCurrentProductTitle() {
+      const titleNode = document.querySelector("#productTitle");
+      const rawTitle = titleNode ? titleNode.textContent : "";
+      const normalizedTitle = String(rawTitle || "").replace(/\s+/g, " ").trim();
+      return normalizedTitle || null;
+    }
+
+    getCurrentProductUrl(asin) {
+      const canonical = document.querySelector('link[rel="canonical"]');
+      const canonicalHref = canonical && canonical.getAttribute("href");
+      if (canonicalHref) {
+        return canonicalHref;
+      }
+
+      return asin ? `https://www.amazon.co.jp/dp/${asin}` : null;
+    }
+
     async refreshForCurrentPage({ forceRefresh = false } = {}) {
       if (!window.AsinExtractor || !window.UiDisplay) {
         return;
@@ -45,6 +62,8 @@
       this.pendingRefresh = false;
       this.pendingForceRefresh = false;
       window.UiDisplay.renderLoading(`https://sakura-checker.jp/search/${asin}/`);
+      const productTitle = this.getCurrentProductTitle();
+      const productUrl = this.getCurrentProductUrl(asin);
       let latestAsin = asin;
 
       try {
@@ -52,6 +71,8 @@
           action: "checkSakuraScore",
           asin,
           forceRefresh,
+          productTitle,
+          productUrl,
         });
 
         latestAsin = this.getCurrentPageAsin();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -545,6 +545,75 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN", asyn
   assert.deepEqual(second.score, first.score);
 });
 
+test("checkSakuraScore does not deduplicate concurrent requests for the same ASIN when fallback inputs differ", async () => {
+  apiClient.__testing.reset();
+  const startedRequests = [];
+  const resolvers = [];
+
+  const fetchRenderedScoreImpl = async ({ asin, searchWord, urlSearchProductUrl, sourceUrl }) => {
+    startedRequests.push({
+      asin,
+      searchWord: searchWord || null,
+      urlSearchProductUrl: urlSearchProductUrl || null,
+      sourceUrl,
+    });
+
+    return new Promise((resolve) => {
+      resolvers.push(resolve);
+    });
+  };
+
+  const firstPromise = apiClient.checkSakuraScore({
+    asin: "B0D5RJ5BDX",
+    productTitle: "",
+    productUrl: "",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+  const secondPromise = apiClient.checkSakuraScore({
+    asin: "B0D5RJ5BDX",
+    productTitle: "Sample product title",
+    productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+    forceRefresh: true,
+    fetchRenderedScoreImpl,
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(resolvers.length, 1);
+
+  resolvers[0]({
+    ok: false,
+    code: "parse_error",
+    message: "Could not extract a rendered Sakura Checker score.",
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(resolvers.length, 2);
+
+  resolvers[1]({
+    ok: true,
+    score: {
+      kind: "text",
+      value: "4.99",
+      suffix: "/5",
+    },
+    verdict: null,
+  });
+
+  const [first, second] = await Promise.all([firstPromise, secondPromise]);
+  assert.equal(first.ok, false);
+  assert.equal(second.ok, true);
+  assert.equal(startedRequests.length, 2);
+  assert.deepEqual(startedRequests.map((request) => request.sourceUrl), [
+    "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
+    "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
+  ]);
+});
+
 test("checkSakuraScore serializes concurrent requests for different ASINs", async () => {
   apiClient.__testing.reset();
   const startedAsins = [];

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -295,6 +295,107 @@ test("checkSakuraScore falls back to an Amazon product URL search when itemsearc
   });
 });
 
+test("checkSakuraScore retries with the product title before the product URL fallback", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0D5RJ5BDX",
+    productTitle: "Sample product title",
+    productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: "4.99",
+          suffix: "/5",
+        },
+        verdict: {
+          kind: "text-verdict",
+          lines: ["合格", "サクラ度 0%"],
+        },
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "text");
+  assert.equal(result.score.value, "4.99");
+  assert.deepEqual(calls, [
+    {
+      asin: "B0D5RJ5BDX",
+      sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
+    },
+    {
+      asin: "B0D5RJ5BDX",
+      sourceUrl: "https://sakura-checker.jp/",
+      searchWord: "Sample product title",
+    },
+  ]);
+});
+
+test("checkSakuraScore falls back to a product URL search after the product title backup fails", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0D5RJ5BDX",
+    productTitle: "Sample product title",
+    productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length < 3) {
+        return {
+          ok: false,
+          code: "parse_error",
+          message: "Could not extract a rendered Sakura Checker score.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "score" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls[1], {
+    asin: "B0D5RJ5BDX",
+    sourceUrl: "https://sakura-checker.jp/",
+    searchWord: "Sample product title",
+  });
+  assert.deepEqual(calls[2], {
+    asin: "B0D5RJ5BDX",
+    sourceUrl: "https://sakura-checker.jp/search/B0D5RJ5BDX/",
+    urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+  });
+});
+
 test("checkSakuraScore returns the fallback error when URL-search retry also fails", async () => {
   apiClient.__testing.reset();
   const calls = [];

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -396,6 +396,53 @@ test("checkSakuraScore falls back to a product URL search after the product titl
   });
 });
 
+test("checkSakuraScore skips the title backup when productTitle is empty and uses the provided product URL", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0D5RJ5BDX",
+    productTitle: "",
+    productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "parse_error",
+          message: "Could not extract a rendered Sakura Checker score.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "visual-image",
+          images: [{ src: "data:image/png;base64,AAAA", alt: "score" }],
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], {
+    asin: "B0D5RJ5BDX",
+    sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
+  });
+  assert.deepEqual(calls[1], {
+    asin: "B0D5RJ5BDX",
+    sourceUrl: "https://sakura-checker.jp/search/B0D5RJ5BDX/",
+    urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+  });
+});
+
 test("checkSakuraScore returns the fallback error when URL-search retry also fails", async () => {
   apiClient.__testing.reset();
   const calls = [];

--- a/tests/background-flow.test.js
+++ b/tests/background-flow.test.js
@@ -101,3 +101,24 @@ test("background defaults forceRefresh to false when omitted", async () => {
   assert.equal(responsePayload.ok, true);
   assert.equal(responsePayload.cached, true);
 });
+
+test("background forwards product title and product URL to ApiClient", async () => {
+  const { apiCalls, onMessage } = loadBackgroundContext();
+
+  onMessage(
+    {
+      action: "checkSakuraScore",
+      asin: "B095JGJCC7",
+      productTitle: "Sample product title",
+      productUrl: "https://www.amazon.co.jp/dp/B095JGJCC7",
+    },
+    null,
+    () => {}
+  );
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(apiCalls.length, 1);
+  assert.equal(apiCalls[0].productTitle, "Sample product title");
+  assert.equal(apiCalls[0].productUrl, "https://www.amazon.co.jp/dp/B095JGJCC7");
+});

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -431,6 +431,10 @@ test("AsinExtractor still detects standard product URLs under the music section"
 
 test("SakuraChecker refresh shows loading first and then renders fetched score images", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
+  const productTitle = document.createElement("span");
+  productTitle.id = "productTitle";
+  productTitle.textContent = "Sample product title";
+  document.body.appendChild(productTitle);
   let resolveResponse = null;
   const chrome = {
     runtime: {
@@ -454,6 +458,11 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(loadingRoot.dataset.state, "loading");
   assert.ok(resolveResponse);
   assert.equal(resolveResponse.payload.asin, "B095JGJCC7");
+  assert.equal(resolveResponse.payload.productTitle, "Sample product title");
+  assert.equal(
+    resolveResponse.payload.productUrl,
+    "https://www.amazon.co.jp/dp/B095JGJCC7"
+  );
 
   resolveResponse.resolve({
     ok: true,

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -726,6 +726,36 @@ const itemSearchNoResultsHtml = `
   </html>
 `;
 
+const itemSearchDetailLinkOnlyHtml = `
+  <!DOCTYPE html>
+  <html lang="ja">
+    <body>
+      <div class="list-wrap marginsideless-sp">
+        <div name="searchitem" sakura="0">
+          <div class="is-flex list-box">
+            <div class="list-item-image">
+              <a href="https://www.amazon.co.jp/dp/B0D5RJ5BDX?tag=sakurachecker-22" target="_blank" class="linkimg"></a>
+            </div>
+            <div class="list-info">
+              <p class="item-name">
+                Product title
+                <a href="https://www.amazon.co.jp/dp/B0D5RJ5BDX?tag=sakurachecker-22" rel="nofollow" target="_blank">...</a>
+              </p>
+              <p class="item-info">
+                <span class="loader" style="height: 20px; width: 20px;"></span>
+              </p>
+              <p class="buttons">
+                <a href="https://www.amazon.co.jp/dp/B0D5RJ5BDX?tag=sakurachecker-22" class="button is-primary is-small" target="_blank">詳細を見る</a>
+                <a href="/search/B0D5RJ5BDX/" class="button is-small">サクラ度確認</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </body>
+  </html>
+`;
+
 const productAndModernHtml = sampleHtml.replace(
   "</body>",
   `
@@ -755,6 +785,7 @@ module.exports = {
   comparisonPrimaryItemInfo,
   comparisonSecondaryItemInfo,
   htmlWithInjectedScore,
+  itemSearchDetailLinkOnlyHtml,
   itemSearchNoResultsHtml,
   itemSearchResultHtml,
   injectedDecodedScript,

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -163,7 +163,7 @@ function installChromeStub({
           typeof details.args[0] === "string" &&
           (typeof shouldSimulateSearchReload === "function"
             ? shouldSimulateSearchReload(details.args[0])
-            : /amazon\.co\.jp\/dp\//.test(details.args[0]))
+            : Boolean(details.args[0] && details.args[0].trim()))
         ) {
           const tab = tabs.get(details.target.tabId);
           if (tab) {
@@ -492,6 +492,53 @@ test("fetchRenderedScore can submit a generic Sakura Checker search term before 
     assert.equal(result.score.kind, "text");
     assert.deepEqual(stub.requestSubmitCalls, ["Sample product title"]);
     assert.deepEqual(stub.submitCalls, []);
+  } finally {
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore prefers searchWord over urlSearchProductUrl when both are provided", async () => {
+  const stub = installChromeStub({
+    shouldSimulateSearchReload(value) {
+      return value === "Preferred search term";
+    },
+    scriptResponder(details, _callCount, submissionState) {
+      if (
+        Array.isArray(details.args) &&
+        details.args.length === 1 &&
+        details.args[0] === "Preferred search term"
+      ) {
+        return runSearchScript(details, {
+          requestSubmitCalls: submissionState.requestSubmitCalls,
+          submitCalls: submissionState.submitCalls,
+          hasSetActionSearchForm: true,
+        });
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: "4.99",
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B0D5RJ5BDX",
+      sourceUrl: "https://sakura-checker.jp/",
+      searchWord: "Preferred search term",
+      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+      timeoutMs: 200,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(stub.requestSubmitCalls, ["Preferred search term"]);
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -7,7 +7,7 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function runUrlSearchScript(details, options = {}) {
+function runSearchScript(details, options = {}) {
   const requestSubmitCalls = options.requestSubmitCalls || [];
   const submitCalls = options.submitCalls || [];
   const hasInput = options.hasInput !== false;
@@ -15,7 +15,7 @@ function runUrlSearchScript(details, options = {}) {
   const hasSetActionSearchForm = Boolean(options.hasSetActionSearchForm);
   const hasRequestSubmit = options.hasRequestSubmit !== false;
   const hasSubmit = options.hasSubmit !== false;
-  const productUrl = Array.isArray(details.args) ? details.args[0] : null;
+  const searchWord = Array.isArray(details.args) ? details.args[0] : null;
 
   const input = hasInput
     ? {
@@ -29,12 +29,12 @@ function runUrlSearchScript(details, options = {}) {
     ? {
         requestSubmit: hasRequestSubmit
           ? () => {
-              requestSubmitCalls.push(productUrl);
+              requestSubmitCalls.push(searchWord);
             }
           : undefined,
         submit: hasSubmit
           ? () => {
-              submitCalls.push(productUrl);
+              submitCalls.push(searchWord);
             }
           : undefined,
       }
@@ -57,7 +57,7 @@ function runUrlSearchScript(details, options = {}) {
   global.self = hasSetActionSearchForm
     ? {
         setactionsearchForm() {
-          requestSubmitCalls.push(productUrl);
+          requestSubmitCalls.push(searchWord);
         },
       }
     : {};
@@ -83,6 +83,7 @@ function installChromeStub({
   parserInjectionResponder,
   scriptResponder,
   simulateUrlSearchReload = true,
+  shouldSimulateSearchReload,
 }) {
   const listeners = new Set();
   const tabs = new Map();
@@ -160,7 +161,9 @@ function installChromeStub({
           Array.isArray(details.args) &&
           details.args.length === 1 &&
           typeof details.args[0] === "string" &&
-          /amazon\.co\.jp\/dp\//.test(details.args[0])
+          (typeof shouldSimulateSearchReload === "function"
+            ? shouldSimulateSearchReload(details.args[0])
+            : /amazon\.co\.jp\/dp\//.test(details.args[0]))
         ) {
           const tab = tabs.get(details.target.tabId);
           if (tab) {
@@ -404,7 +407,7 @@ test("fetchRenderedScore can trigger a Sakura Checker product URL search before 
         typeof details.args[0] === "string" &&
         /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
       ) {
-        return runUrlSearchScript(details, {
+        return runSearchScript(details, {
           requestSubmitCalls: submissionState.requestSubmitCalls,
           submitCalls: submissionState.submitCalls,
           hasSetActionSearchForm: true,
@@ -440,6 +443,54 @@ test("fetchRenderedScore can trigger a Sakura Checker product URL search before 
     assert.deepEqual(stub.executeDetails[1].files, ["background/rendered-score-parser.js"]);
     assert.deepEqual(stub.executeDetails[2].args, ["B0BJDY6D1W"]);
     assert.deepEqual(stub.requestSubmitCalls, ["https://www.amazon.co.jp/dp/B0BJDY6D1W"]);
+    assert.deepEqual(stub.submitCalls, []);
+  } finally {
+    stub.cleanup();
+  }
+});
+
+test("fetchRenderedScore can submit a generic Sakura Checker search term before extracting", async () => {
+  const stub = installChromeStub({
+    shouldSimulateSearchReload(value) {
+      return value === "Sample product title";
+    },
+    scriptResponder(details, _callCount, submissionState) {
+      if (
+        Array.isArray(details.args) &&
+        details.args.length === 1 &&
+        details.args[0] === "Sample product title"
+      ) {
+        return runSearchScript(details, {
+          requestSubmitCalls: submissionState.requestSubmitCalls,
+          submitCalls: submissionState.submitCalls,
+          hasSetActionSearchForm: true,
+        });
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: "4.99",
+          suffix: "/5",
+        },
+        verdict: null,
+      };
+    },
+  });
+
+  try {
+    const result = await renderedScoreClient.fetchRenderedScore({
+      asin: "B0D5RJ5BDX",
+      sourceUrl: "https://sakura-checker.jp/",
+      searchWord: "Sample product title",
+      timeoutMs: 200,
+      pollIntervalMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.score.kind, "text");
+    assert.deepEqual(stub.requestSubmitCalls, ["Sample product title"]);
     assert.deepEqual(stub.submitCalls, []);
   } finally {
     stub.cleanup();
@@ -508,7 +559,7 @@ test("fetchRenderedScore falls back to form.submit when requestSubmit is unavail
         typeof details.args[0] === "string" &&
         /amazon\.co\.jp\/dp\/B0BJDY6D1W/.test(details.args[0])
       ) {
-        return runUrlSearchScript(details, {
+        return runSearchScript(details, {
           requestSubmitCalls: submissionState.requestSubmitCalls,
           submitCalls: submissionState.submitCalls,
           hasRequestSubmit: false,

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -54,6 +54,18 @@ test("extractRenderedScore reports when itemsearch asks for an Amazon product UR
   assert.equal(result.retryable, false);
 });
 
+test("extractRenderedScore falls back to the product detail page when itemsearch only exposes a detail link", () => {
+  const document = parseDocument(
+    fixtures.itemSearchDetailLinkOnlyHtml,
+    "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA=="
+  );
+  const result = renderedParser.extractRenderedScore(document, "B0D5RJ5BDX");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "url_search_required");
+  assert.equal(result.retryable, false);
+});
+
 test("extractRenderedScore prefers the richest rendered product card", () => {
   const document = parseDocument(fixtures.comparisonHeavyProductHtml);
   const result = renderedParser.extractRenderedScore(document);


### PR DESCRIPTION
## Summary
- add fallback Sakura Checker lookups using the Amazon product title and product URL when ASIN-based lookup cannot produce a score
- pass product title and canonical product URL from the content script through the background flow
- bump the extension patch version to 2.1.5 and add regression coverage for the new fallback path

## Testing
- npm test
- SAKURA_E2E_ASIN=B0D5RJ5BDX node scripts/run-extension-e2e.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- ASIN ベースの検索結果が得られない場合のフォールバック検索を追加 / Sakura Checker のホームでの商品タイトル検索を実装して、ASIN が未解決の商品のスコア取得を可能にするため

- コンテンツスクリプトから商品タイトルと正規化された商品 URL をバックグラウンドに送信 / フォールバック検索機能でこれらの情報を活用するため

- ApiClient に複数段階の再試行ロジックを実装（商品タイトル検索→Amazon 商品 URL 検索） / ASIN 検索失敗時に段階的に異なる検索キーワードで再試行するため

- rendered-score-parser で `url_search_required` エラーを新規追加し、検索リンク検出時に発火 / フォールバック検索トリガーの判定を明確にするため

- 拡張機能バージョンを 2.1.5 に更新、新機能の回帰テストを追加 / リリース対応とコード品質保証のため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->