### PR TITLE
Use ASIN/url-only Sakura search and bump version to 2.1.6

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,7 +11,6 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   self.ApiClient.checkSakuraScore({
     asin: request.asin,
     forceRefresh: request.forceRefresh === true,
-    productTitle: request.productTitle,
     productUrl: request.productUrl,
   })
     .then((result) => sendResponse(result))

--- a/background/api-client.js
+++ b/background/api-client.js
@@ -15,7 +15,6 @@
   const CACHE_PREFIX = "score:";
   const MIN_REQUEST_INTERVAL_MS = 2000;
   const MAX_REQUEST_JITTER_MS = 250;
-  const SAKURA_HOME_URL = "https://sakura-checker.jp/";
   const BACKUP_ERROR_CODES = new Set([
     "not_found",
     "not_ready",
@@ -44,10 +43,6 @@
     return `https://sakura-checker.jp/search/${asin}/`;
   }
 
-  function buildHomeUrl() {
-    return SAKURA_HOME_URL;
-  }
-
   function buildAmazonProductUrl(asin) {
     return `https://www.amazon.co.jp/dp/${encodeURIComponent(String(asin || ""))}`;
   }
@@ -56,11 +51,9 @@
     return String(value || "").replace(/\s+/g, " ").trim();
   }
 
-  function buildInFlightRequestKey({ asin, productTitle, productUrl }) {
+  function buildInFlightRequestKey({ asin }) {
     return JSON.stringify({
       asin: String(asin || ""),
-      productTitle: normalizeSearchWord(productTitle),
-      productUrl: normalizeSearchWord(productUrl),
     });
   }
 
@@ -335,7 +328,6 @@
 
   async function fetchFreshScore({
     asin,
-    productTitle,
     productUrl,
     fetchRenderedScore,
     nowImpl,
@@ -344,7 +336,6 @@
   }) {
     const requestUrl = buildSourceUrl(asin);
     const sourceUrl = buildDetailUrl(asin);
-    const normalizedProductTitle = normalizeSearchWord(productTitle);
     const normalizedProductUrl = normalizeSearchWord(productUrl);
     let renderedResult = null;
 
@@ -363,22 +354,9 @@
       sourceUrl
     );
 
-    if (shouldRetryWithBackupSearch(renderedResult) && normalizedProductTitle) {
-      renderedResult = await attemptRenderedFetch(
-        fetchRenderedScore,
-        {
-          asin,
-          sourceUrl: buildHomeUrl(),
-          searchWord: normalizedProductTitle,
-        },
-        sourceUrl
-      );
-    }
-
     if (
       shouldRetryWithProductUrl(renderedResult) ||
-      (shouldRetryWithBackupSearch(renderedResult) &&
-        (normalizedProductUrl || normalizedProductTitle))
+      shouldRetryWithBackupSearch(renderedResult)
     ) {
       renderedResult = await attemptRenderedFetch(
         fetchRenderedScore,
@@ -411,7 +389,6 @@
   async function checkSakuraScore({
     asin,
     forceRefresh = false,
-    productTitle,
     productUrl,
     fetchRenderedScoreImpl,
     nowImpl,
@@ -441,8 +418,6 @@
         : RenderedScoreClient.fetchRenderedScore;
     const requestKey = buildInFlightRequestKey({
       asin,
-      productTitle,
-      productUrl,
     });
 
     if (inFlightRequests.has(requestKey)) {
@@ -453,7 +428,6 @@
       .enqueue(() =>
         fetchFreshScore({
           asin,
-          productTitle,
           productUrl,
           fetchRenderedScore,
           nowImpl,
@@ -474,7 +448,6 @@
   return {
     buildAmazonProductUrl,
     buildDetailUrl,
-    buildHomeUrl,
     buildSourceUrl,
     checkSakuraScore,
     encodeItemSearchWord,

--- a/background/rendered-score-client.js
+++ b/background/rendered-score-client.js
@@ -304,14 +304,14 @@
     };
   }
 
-  async function submitSearch(tabId, searchWord, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
+  async function submitUrlSearch(tabId, productUrl, timeoutMs = DEFAULT_TAB_TIMEOUT_MS) {
     const reloadHandle = waitForTabReload(tabId, timeoutMs);
     let submissionResult = null;
 
     try {
       submissionResult = await executeTabFunction(
         tabId,
-        (submittedSearchWord) => {
+        (submittedProductUrl) => {
           const input = document.querySelector("#urlsearchForm");
           if (!input) {
             return {
@@ -320,8 +320,8 @@
             };
           }
 
-          input.value = submittedSearchWord;
-          input.setAttribute("value", submittedSearchWord);
+          input.value = submittedProductUrl;
+          input.setAttribute("value", submittedProductUrl);
 
           if (typeof self.setactionsearchForm === "function") {
             self.setactionsearchForm(true);
@@ -351,7 +351,7 @@
             message: "The Sakura Checker search form could not be submitted.",
           };
         },
-        [searchWord],
+        [productUrl],
         "Failed to submit the Sakura Checker search."
       );
     } catch (error) {
@@ -489,7 +489,6 @@
     loadTimeoutMs,
     renderTimeoutMs,
     pollIntervalMs,
-    searchWord,
     urlSearchProductUrl,
   }) {
     let tab = null;
@@ -509,14 +508,12 @@
       });
 
       await waitForTabComplete(tab.id, effectiveLoadTimeoutMs);
-      const submittedSearchWord =
-        typeof searchWord === "string" && searchWord.trim()
-          ? searchWord.trim()
-          : typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()
-            ? urlSearchProductUrl.trim()
-            : "";
-      if (submittedSearchWord) {
-        await submitSearch(tab.id, submittedSearchWord, effectiveLoadTimeoutMs);
+      const normalizedProductUrl =
+        typeof urlSearchProductUrl === "string" && urlSearchProductUrl.trim()
+          ? urlSearchProductUrl.trim()
+          : "";
+      if (normalizedProductUrl) {
+        await submitUrlSearch(tab.id, normalizedProductUrl, effectiveLoadTimeoutMs);
       }
       const renderDeadline = Date.now() + effectiveRenderTimeoutMs;
       await injectParserWithRetry(tab.id, {

--- a/content/sakura-checker.js
+++ b/content/sakura-checker.js
@@ -20,13 +20,6 @@
       return window.AsinExtractor.extractProductASIN();
     }
 
-    getCurrentProductTitle() {
-      const titleNode = document.querySelector("#productTitle");
-      const rawTitle = titleNode ? titleNode.textContent : "";
-      const normalizedTitle = String(rawTitle || "").replace(/\s+/g, " ").trim();
-      return normalizedTitle || null;
-    }
-
     getCurrentProductUrl(asin) {
       const canonical = document.querySelector('link[rel="canonical"]');
       const canonicalHref = canonical && canonical.getAttribute("href");
@@ -62,7 +55,6 @@
       this.pendingRefresh = false;
       this.pendingForceRefresh = false;
       window.UiDisplay.renderLoading(`https://sakura-checker.jp/search/${asin}/`);
-      const productTitle = this.getCurrentProductTitle();
       const productUrl = this.getCurrentProductUrl(asin);
       let latestAsin = asin;
 
@@ -71,7 +63,6 @@
           action: "checkSakuraScore",
           asin,
           forceRefresh,
-          productTitle,
           productUrl,
         });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -295,13 +295,12 @@ test("checkSakuraScore falls back to an Amazon product URL search when itemsearc
   });
 });
 
-test("checkSakuraScore retries with the product title before the product URL fallback", async () => {
+test("checkSakuraScore falls back to a product URL search when itemsearch requires it even if a product title is available", async () => {
   apiClient.__testing.reset();
   const calls = [];
 
   const result = await apiClient.checkSakuraScore({
     asin: "B0D5RJ5BDX",
-    productTitle: "Sample product title",
     productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
     forceRefresh: true,
     fetchRenderedScoreImpl: async (options) => {
@@ -342,25 +341,24 @@ test("checkSakuraScore retries with the product title before the product URL fal
     },
     {
       asin: "B0D5RJ5BDX",
-      sourceUrl: "https://sakura-checker.jp/",
-      searchWord: "Sample product title",
+      sourceUrl: "https://sakura-checker.jp/search/B0D5RJ5BDX/",
+      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
     },
   ]);
 });
 
-test("checkSakuraScore falls back to a product URL search after the product title backup fails", async () => {
+test("checkSakuraScore falls back to a product URL search after an itemsearch parse failure", async () => {
   apiClient.__testing.reset();
   const calls = [];
 
   const result = await apiClient.checkSakuraScore({
     asin: "B0D5RJ5BDX",
-    productTitle: "Sample product title",
     productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
     forceRefresh: true,
     fetchRenderedScoreImpl: async (options) => {
       calls.push(options);
 
-      if (calls.length < 3) {
+      if (calls.length < 2) {
         return {
           ok: false,
           code: "parse_error",
@@ -383,26 +381,20 @@ test("checkSakuraScore falls back to a product URL search after the product titl
   });
 
   assert.equal(result.ok, true);
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 2);
   assert.deepEqual(calls[1], {
-    asin: "B0D5RJ5BDX",
-    sourceUrl: "https://sakura-checker.jp/",
-    searchWord: "Sample product title",
-  });
-  assert.deepEqual(calls[2], {
     asin: "B0D5RJ5BDX",
     sourceUrl: "https://sakura-checker.jp/search/B0D5RJ5BDX/",
     urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
   });
 });
 
-test("checkSakuraScore skips the title backup when productTitle is empty and uses the provided product URL", async () => {
+test("checkSakuraScore uses the provided product URL when itemsearch parsing fails", async () => {
   apiClient.__testing.reset();
   const calls = [];
 
   const result = await apiClient.checkSakuraScore({
     asin: "B0D5RJ5BDX",
-    productTitle: "",
     productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
     forceRefresh: true,
     fetchRenderedScoreImpl: async (options) => {
@@ -545,15 +537,14 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN", asyn
   assert.deepEqual(second.score, first.score);
 });
 
-test("checkSakuraScore does not deduplicate concurrent requests for the same ASIN when fallback inputs differ", async () => {
+test("checkSakuraScore deduplicates concurrent requests for the same ASIN even when product URLs differ", async () => {
   apiClient.__testing.reset();
   const startedRequests = [];
   const resolvers = [];
 
-  const fetchRenderedScoreImpl = async ({ asin, searchWord, urlSearchProductUrl, sourceUrl }) => {
+  const fetchRenderedScoreImpl = async ({ asin, urlSearchProductUrl, sourceUrl }) => {
     startedRequests.push({
       asin,
-      searchWord: searchWord || null,
       urlSearchProductUrl: urlSearchProductUrl || null,
       sourceUrl,
     });
@@ -565,7 +556,6 @@ test("checkSakuraScore does not deduplicate concurrent requests for the same ASI
 
   const firstPromise = apiClient.checkSakuraScore({
     asin: "B0D5RJ5BDX",
-    productTitle: "",
     productUrl: "",
     forceRefresh: true,
     fetchRenderedScoreImpl,
@@ -574,7 +564,6 @@ test("checkSakuraScore does not deduplicate concurrent requests for the same ASI
   });
   const secondPromise = apiClient.checkSakuraScore({
     asin: "B0D5RJ5BDX",
-    productTitle: "Sample product title",
     productUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
     forceRefresh: true,
     fetchRenderedScoreImpl,
@@ -586,15 +575,6 @@ test("checkSakuraScore does not deduplicate concurrent requests for the same ASI
   assert.equal(resolvers.length, 1);
 
   resolvers[0]({
-    ok: false,
-    code: "parse_error",
-    message: "Could not extract a rendered Sakura Checker score.",
-  });
-
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(resolvers.length, 2);
-
-  resolvers[1]({
     ok: true,
     score: {
       kind: "text",
@@ -605,11 +585,10 @@ test("checkSakuraScore does not deduplicate concurrent requests for the same ASI
   });
 
   const [first, second] = await Promise.all([firstPromise, secondPromise]);
-  assert.equal(first.ok, false);
+  assert.equal(first.ok, true);
   assert.equal(second.ok, true);
-  assert.equal(startedRequests.length, 2);
+  assert.equal(startedRequests.length, 1);
   assert.deepEqual(startedRequests.map((request) => request.sourceUrl), [
-    "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
     "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
   ]);
 });

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -537,7 +537,7 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN", asyn
   assert.deepEqual(second.score, first.score);
 });
 
-test("checkSakuraScore deduplicates concurrent requests for the same ASIN even when product URLs differ", async () => {
+test("checkSakuraScore deduplicates concurrent requests for the same ASIN even when product URLs differ and URL fallback is required", async () => {
   apiClient.__testing.reset();
   const startedRequests = [];
   const resolvers = [];
@@ -573,8 +573,28 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN even w
 
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(resolvers.length, 1);
+  assert.equal(startedRequests.length, 1);
 
   resolvers[0]({
+    ok: false,
+    code: "parse_error",
+    message: "Could not extract a rendered Sakura Checker score.",
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(resolvers.length, 2);
+  assert.equal(startedRequests.length, 2);
+  assert.equal(
+    startedRequests.filter((request) => request.urlSearchProductUrl).length,
+    1
+  );
+  assert.deepEqual(startedRequests[1], {
+    asin: "B0D5RJ5BDX",
+    urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
+    sourceUrl: "https://sakura-checker.jp/search/B0D5RJ5BDX/",
+  });
+
+  resolvers[1]({
     ok: true,
     score: {
       kind: "text",
@@ -587,9 +607,9 @@ test("checkSakuraScore deduplicates concurrent requests for the same ASIN even w
   const [first, second] = await Promise.all([firstPromise, secondPromise]);
   assert.equal(first.ok, true);
   assert.equal(second.ok, true);
-  assert.equal(startedRequests.length, 1);
   assert.deepEqual(startedRequests.map((request) => request.sourceUrl), [
     "https://sakura-checker.jp/itemsearch/?word=QjBENVJKNUJEWA==",
+    "https://sakura-checker.jp/search/B0D5RJ5BDX/",
   ]);
 });
 

--- a/tests/background-flow.test.js
+++ b/tests/background-flow.test.js
@@ -102,14 +102,13 @@ test("background defaults forceRefresh to false when omitted", async () => {
   assert.equal(responsePayload.cached, true);
 });
 
-test("background forwards product title and product URL to ApiClient", async () => {
+test("background forwards the product URL to ApiClient", async () => {
   const { apiCalls, onMessage } = loadBackgroundContext();
 
   onMessage(
     {
       action: "checkSakuraScore",
       asin: "B095JGJCC7",
-      productTitle: "Sample product title",
       productUrl: "https://www.amazon.co.jp/dp/B095JGJCC7",
     },
     null,
@@ -119,6 +118,5 @@ test("background forwards product title and product URL to ApiClient", async () 
   await new Promise((resolve) => setImmediate(resolve));
 
   assert.equal(apiCalls.length, 1);
-  assert.equal(apiCalls[0].productTitle, "Sample product title");
   assert.equal(apiCalls[0].productUrl, "https://www.amazon.co.jp/dp/B095JGJCC7");
 });

--- a/tests/content-flow.test.js
+++ b/tests/content-flow.test.js
@@ -431,10 +431,6 @@ test("AsinExtractor still detects standard product URLs under the music section"
 
 test("SakuraChecker refresh shows loading first and then renders fetched score images", async () => {
   const document = createPageDocument("https://www.amazon.co.jp/dp/B095JGJCC7");
-  const productTitle = document.createElement("span");
-  productTitle.id = "productTitle";
-  productTitle.textContent = "Sample product title";
-  document.body.appendChild(productTitle);
   let resolveResponse = null;
   const chrome = {
     runtime: {
@@ -458,7 +454,6 @@ test("SakuraChecker refresh shows loading first and then renders fetched score i
   assert.equal(loadingRoot.dataset.state, "loading");
   assert.ok(resolveResponse);
   assert.equal(resolveResponse.payload.asin, "B095JGJCC7");
-  assert.equal(resolveResponse.payload.productTitle, "Sample product title");
   assert.equal(
     resolveResponse.payload.productUrl,
     "https://www.amazon.co.jp/dp/B095JGJCC7"

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -15,7 +15,7 @@ function runSearchScript(details, options = {}) {
   const hasSetActionSearchForm = Boolean(options.hasSetActionSearchForm);
   const hasRequestSubmit = options.hasRequestSubmit !== false;
   const hasSubmit = options.hasSubmit !== false;
-  const searchWord = Array.isArray(details.args) ? details.args[0] : null;
+  const submittedValue = Array.isArray(details.args) ? details.args[0] : null;
 
   const input = hasInput
     ? {
@@ -29,12 +29,12 @@ function runSearchScript(details, options = {}) {
     ? {
         requestSubmit: hasRequestSubmit
           ? () => {
-              requestSubmitCalls.push(searchWord);
+              requestSubmitCalls.push(submittedValue);
             }
           : undefined,
         submit: hasSubmit
           ? () => {
-              submitCalls.push(searchWord);
+              submitCalls.push(submittedValue);
             }
           : undefined,
       }
@@ -57,7 +57,7 @@ function runSearchScript(details, options = {}) {
   global.self = hasSetActionSearchForm
     ? {
         setactionsearchForm() {
-          requestSubmitCalls.push(searchWord);
+          requestSubmitCalls.push(submittedValue);
         },
       }
     : {};
@@ -444,101 +444,6 @@ test("fetchRenderedScore can trigger a Sakura Checker product URL search before 
     assert.deepEqual(stub.executeDetails[2].args, ["B0BJDY6D1W"]);
     assert.deepEqual(stub.requestSubmitCalls, ["https://www.amazon.co.jp/dp/B0BJDY6D1W"]);
     assert.deepEqual(stub.submitCalls, []);
-  } finally {
-    stub.cleanup();
-  }
-});
-
-test("fetchRenderedScore can submit a generic Sakura Checker search term before extracting", async () => {
-  const stub = installChromeStub({
-    shouldSimulateSearchReload(value) {
-      return value === "Sample product title";
-    },
-    scriptResponder(details, _callCount, submissionState) {
-      if (
-        Array.isArray(details.args) &&
-        details.args.length === 1 &&
-        details.args[0] === "Sample product title"
-      ) {
-        return runSearchScript(details, {
-          requestSubmitCalls: submissionState.requestSubmitCalls,
-          submitCalls: submissionState.submitCalls,
-          hasSetActionSearchForm: true,
-        });
-      }
-
-      return {
-        ok: true,
-        score: {
-          kind: "text",
-          value: "4.99",
-          suffix: "/5",
-        },
-        verdict: null,
-      };
-    },
-  });
-
-  try {
-    const result = await renderedScoreClient.fetchRenderedScore({
-      asin: "B0D5RJ5BDX",
-      sourceUrl: "https://sakura-checker.jp/",
-      searchWord: "Sample product title",
-      timeoutMs: 200,
-      pollIntervalMs: 1,
-    });
-
-    assert.equal(result.ok, true);
-    assert.equal(result.score.kind, "text");
-    assert.deepEqual(stub.requestSubmitCalls, ["Sample product title"]);
-    assert.deepEqual(stub.submitCalls, []);
-  } finally {
-    stub.cleanup();
-  }
-});
-
-test("fetchRenderedScore prefers searchWord over urlSearchProductUrl when both are provided", async () => {
-  const stub = installChromeStub({
-    shouldSimulateSearchReload(value) {
-      return value === "Preferred search term";
-    },
-    scriptResponder(details, _callCount, submissionState) {
-      if (
-        Array.isArray(details.args) &&
-        details.args.length === 1 &&
-        details.args[0] === "Preferred search term"
-      ) {
-        return runSearchScript(details, {
-          requestSubmitCalls: submissionState.requestSubmitCalls,
-          submitCalls: submissionState.submitCalls,
-          hasSetActionSearchForm: true,
-        });
-      }
-
-      return {
-        ok: true,
-        score: {
-          kind: "text",
-          value: "4.99",
-          suffix: "/5",
-        },
-        verdict: null,
-      };
-    },
-  });
-
-  try {
-    const result = await renderedScoreClient.fetchRenderedScore({
-      asin: "B0D5RJ5BDX",
-      sourceUrl: "https://sakura-checker.jp/",
-      searchWord: "Preferred search term",
-      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0D5RJ5BDX",
-      timeoutMs: 200,
-      pollIntervalMs: 1,
-    });
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(stub.requestSubmitCalls, ["Preferred search term"]);
   } finally {
     stub.cleanup();
   }

--- a/tests/rendered-score-client.test.js
+++ b/tests/rendered-score-client.test.js
@@ -15,26 +15,34 @@ function runSearchScript(details, options = {}) {
   const hasSetActionSearchForm = Boolean(options.hasSetActionSearchForm);
   const hasRequestSubmit = options.hasRequestSubmit !== false;
   const hasSubmit = options.hasSubmit !== false;
-  const submittedValue = Array.isArray(details.args) ? details.args[0] : null;
 
   const input = hasInput
     ? {
+        attributes: new Map(),
         value: "",
-        setAttribute(_name, value) {
-          this.value = value;
+        getAttribute(name) {
+          return this.attributes.has(name) ? this.attributes.get(name) : null;
+        },
+        setAttribute(name, value) {
+          const normalizedValue = String(value);
+          this.attributes.set(name, normalizedValue);
+          if (name === "value") {
+            this.value = normalizedValue;
+          }
         },
       }
     : null;
+  const readInputValue = () => (input ? input.value : null);
   const form = hasForm
     ? {
         requestSubmit: hasRequestSubmit
           ? () => {
-              requestSubmitCalls.push(submittedValue);
+              requestSubmitCalls.push(readInputValue());
             }
           : undefined,
         submit: hasSubmit
           ? () => {
-              submitCalls.push(submittedValue);
+              submitCalls.push(readInputValue());
             }
           : undefined,
       }
@@ -57,7 +65,7 @@ function runSearchScript(details, options = {}) {
   global.self = hasSetActionSearchForm
     ? {
         setactionsearchForm() {
-          requestSubmitCalls.push(submittedValue);
+          requestSubmitCalls.push(readInputValue());
         },
       }
     : {};


### PR DESCRIPTION
## Summary
- remove the product-title Sakura Checker fallback and keep lookup flow to ASIN itemsearch plus Amazon product URL only
- delete unused generic search-word handling and update tests for the simplified lookup path
- bump the extension patch version to 2.1.6 and sync manifest/package metadata

## Testing
- npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Sakura Checker検索ロジックを簡略化**: `productTitle`を使用した検索フローを削除し、ASIN + Amazon商品URLのみでの検索に統一。これにより複数の検索パスを削除し、コード複雑性を低減した。

- **バックアップ検索機能を削除**: `buildHomeUrl()`関数とSakura Checker homepageを使用した専用バックアップ検索パスを廃止。ASINベースの検索とURL検索へのフェイルオーバーのみに統一した。

- **リクエストのデ重複化キーを簡略化**: `buildInFlightRequestKey`をASINのみでハッシュ化するように変更し、URLが異なっていても同一商品の並行リクエストを適切に重複排除できるようにした。

- **テストケースを実装に合わせて更新**: `productTitle`関連のテストアサーションを削除し、URL検索フローのみを検証するようテストを整理。削除されたロジックのテストケースも廃止した。

- **拡張機能バージョンを2.1.6に更新**: manifest.jsonとpackage.jsonのバージョン番号を2.1.5から2.1.6に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->