### PR TITLE
[codex] Strengthen Sakura Checker score fallback

### DIFF
--- a/background/api-client.js
+++ b/background/api-client.js
@@ -128,6 +128,10 @@
     return Boolean(payload && payload.ok === true && hasValidScorePayload(payload.score));
   }
 
+  function isPercentScorePayload(payload) {
+    return Boolean(payload && payload.score && payload.score.suffix === "%");
+  }
+
   function createStorageAdapter() {
     function hasStorage() {
       return (
@@ -367,6 +371,36 @@
         },
         sourceUrl
       );
+    }
+
+    if (isPercentScorePayload(renderedResult)) {
+      const detailResult = await attemptRenderedFetch(
+        fetchRenderedScore,
+        {
+          asin,
+          sourceUrl,
+        },
+        sourceUrl
+      );
+      if (hasValidSuccessPayload(detailResult) && !isPercentScorePayload(detailResult)) {
+        renderedResult = detailResult;
+      }
+    }
+
+    if (shouldRetryWithBackupSearch(renderedResult)) {
+      const asinSearchResult = await attemptRenderedFetch(
+        fetchRenderedScore,
+        {
+          asin,
+          sourceUrl: requestUrl,
+        },
+        sourceUrl
+      );
+      if (hasValidSuccessPayload(asinSearchResult) && !isPercentScorePayload(asinSearchResult)) {
+        renderedResult = asinSearchResult;
+      } else {
+        renderedResult = asinSearchResult;
+      }
     }
 
     if (!renderedResult || !renderedResult.ok) {

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -206,6 +206,94 @@
     );
   }
 
+  function getComputedStyleForNode(context, node) {
+    const view =
+      (context.root.defaultView || null) ||
+      (context.root.ownerDocument && context.root.ownerDocument.defaultView) ||
+      (typeof window !== "undefined" ? window : null);
+
+    if (!view || typeof view.getComputedStyle !== "function") {
+      return null;
+    }
+
+    try {
+      return view.getComputedStyle(node);
+    } catch {
+      return null;
+    }
+  }
+
+  function isHiddenByInlineStyle(node) {
+    const styleText = String(node.getAttribute("style") || "");
+    return /(?:^|;)\s*display\s*:\s*none\s*(?:;|$)/i.test(styleText);
+  }
+
+  function getVisibleChildItemInfos(context, reviewWrap) {
+    const itemInfos = getDirectChildItemInfos(reviewWrap);
+    if (itemInfos.length < 2) {
+      return null;
+    }
+
+    let detectedHiddenItem = false;
+    const visibleItemInfos = itemInfos.filter((itemInfo) => {
+      if (itemInfo.hidden || isHiddenByInlineStyle(itemInfo)) {
+        detectedHiddenItem = true;
+        return false;
+      }
+
+      const style = getComputedStyleForNode(context, itemInfo);
+      if (!style) {
+        return true;
+      }
+
+      const isHidden =
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        style.visibility === "collapse" ||
+        style.opacity === "0";
+      if (isHidden) {
+        detectedHiddenItem = true;
+        return false;
+      }
+
+      return true;
+    });
+
+    if (!detectedHiddenItem || visibleItemInfos.length === itemInfos.length) {
+      return null;
+    }
+
+    return visibleItemInfos;
+  }
+
+  function hasLegacyScoreSignals(context, itemInfo) {
+    return Boolean(
+      itemInfo &&
+        (getRatingImages(context, itemInfo.querySelectorAll("p.item-rating")).length ||
+          itemInfo.querySelector(".item-rv-score"))
+    );
+  }
+
+  function hasPendingVisibleRequestedLegacyCard(context) {
+    if (!context.requestedAsinPattern) {
+      return false;
+    }
+
+    return Array.from(context.root.querySelectorAll(".item-review-wrap")).some((reviewWrap) => {
+      if (!reviewWrapMatchesRequestedAsin(context, reviewWrap)) {
+        return false;
+      }
+
+      const itemInfos = getDirectChildItemInfos(reviewWrap);
+      if (itemInfos.length < 2 || !itemInfos.some((itemInfo) => hasLegacyScoreSignals(context, itemInfo))) {
+        return false;
+      }
+
+      const visibleItemInfos = getVisibleChildItemInfos(context, reviewWrap);
+      return Array.isArray(visibleItemInfos) && visibleItemInfos.length === 0;
+    });
+  }
+
   function reviewWrapMatchesRequestedAsin(context, reviewWrap) {
     if (!context.requestedAsinPattern || !reviewWrap) {
       return false;
@@ -367,12 +455,18 @@
         const ambiguousWrapCandidates = matchingWraps.flatMap((reviewWrap) =>
           getDirectChildItemInfos(reviewWrap)
         );
+        const visibleWrapCandidates = matchingWraps.flatMap((reviewWrap) =>
+          getVisibleChildItemInfos(context, reviewWrap) || []
+        );
         const singleCardWrapCandidates = matchingWraps
           .map((reviewWrap) => getDirectChildItemInfos(reviewWrap))
           .filter((itemInfos) => itemInfos.length === 1)
           .map((itemInfos) => itemInfos[0]);
 
-        if (singleCardWrapCandidates.length) {
+        if (visibleWrapCandidates.length) {
+          matchingCandidates = visibleWrapCandidates;
+          scopedCandidates = visibleWrapCandidates;
+        } else if (singleCardWrapCandidates.length) {
           matchingCandidates = singleCardWrapCandidates;
           scopedCandidates = singleCardWrapCandidates;
         } else if (allowAmbiguousMatches && ambiguousWrapCandidates.length) {
@@ -694,6 +788,14 @@
     const legacy = extractLegacyScore(context);
     if (legacy && legacy.ok) {
       return legacy;
+    }
+
+    if (hasPendingVisibleRequestedLegacyCard(context)) {
+      return createFailure(
+        "not_ready",
+        "Rendered Sakura Checker product score card is not visible yet.",
+        true
+      );
     }
 
     const modern = extractModernScore(context);

--- a/background/rendered-score-parser.js
+++ b/background/rendered-score-parser.js
@@ -230,7 +230,7 @@
 
   function getVisibleChildItemInfos(context, reviewWrap) {
     const itemInfos = getDirectChildItemInfos(reviewWrap);
-    if (itemInfos.length < 2) {
+    if (!itemInfos.length) {
       return null;
     }
 
@@ -285,7 +285,7 @@
       }
 
       const itemInfos = getDirectChildItemInfos(reviewWrap);
-      if (itemInfos.length < 2 || !itemInfos.some((itemInfo) => hasLegacyScoreSignals(context, itemInfo))) {
+      if (!itemInfos.some((itemInfo) => hasLegacyScoreSignals(context, itemInfo))) {
         return false;
       }
 
@@ -459,9 +459,15 @@
           getVisibleChildItemInfos(context, reviewWrap) || []
         );
         const singleCardWrapCandidates = matchingWraps
-          .map((reviewWrap) => getDirectChildItemInfos(reviewWrap))
-          .filter((itemInfos) => itemInfos.length === 1)
-          .map((itemInfos) => itemInfos[0]);
+          .flatMap((reviewWrap) => {
+            const itemInfos = getDirectChildItemInfos(reviewWrap);
+            if (itemInfos.length !== 1) {
+              return [];
+            }
+
+            const visibleItemInfos = getVisibleChildItemInfos(context, reviewWrap);
+            return Array.isArray(visibleItemInfos) ? visibleItemInfos : itemInfos;
+          });
 
         if (visibleWrapCandidates.length) {
           matchingCandidates = visibleWrapCandidates;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "amazon-display-sakurachecker",
       "version": "2.1.7",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "devDependencies": {
         "archiver": "^8.0.0",
         "linkedom": "^0.18.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,38 +9,9 @@
       "version": "2.1.7",
       "license": "MIT",
       "devDependencies": {
-        "archiver": "^7.0.1",
+        "archiver": "^8.0.0",
         "linkedom": "^0.18.12",
-        "playwright": "^1.58.2"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
+        "playwright": "^1.60.0"
       }
     },
     "node_modules/abort-controller": {
@@ -56,68 +27,25 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "is-stream": "^4.0.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/async": {
@@ -143,11 +71,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
@@ -271,13 +202,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -315,41 +249,21 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/core-util-is": {
@@ -373,9 +287,9 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -383,22 +297,7 @@
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=18"
       }
     },
     "node_modules/css-select": {
@@ -497,20 +396,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -561,23 +446,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -592,35 +460,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
@@ -690,24 +529,14 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -719,29 +548,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -814,44 +620,20 @@
         }
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/normalize-path": {
@@ -877,48 +659,14 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -931,9 +679,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -978,26 +726,19 @@
       }
     },
     "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
       }
     },
     "node_modules/safe-buffer": {
@@ -1021,42 +762,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -1077,110 +782,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tar-stream": {
@@ -1230,133 +831,19 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "archiver": "^7.0.1",
+    "archiver": "^8.0.0",
     "linkedom": "^0.18.12",
-    "playwright": "^1.58.2"
+    "playwright": "^1.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "archiver": "^8.0.0",
     "linkedom": "^0.18.12",

--- a/scripts/create-extension-zip.js
+++ b/scripts/create-extension-zip.js
@@ -3,7 +3,6 @@
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
-const archiver = require("archiver");
 
 const rootDir = path.join(__dirname, "..");
 const outputZipPath = path.join(rootDir, "extension.zip");
@@ -63,6 +62,7 @@ async function createZip() {
   ensureEntriesExist();
   syncManifestVersion();
   validateSyncedVersion();
+  const { ZipArchive } = await import("archiver");
 
   if (fs.existsSync(outputZipPath)) {
     fs.unlinkSync(outputZipPath);
@@ -70,7 +70,7 @@ async function createZip() {
 
   await new Promise((resolve, reject) => {
     const output = fs.createWriteStream(outputZipPath);
-    const archive = archiver("zip", { zlib: { level: 9 } });
+    const archive = new ZipArchive({ zlib: { level: 9 } });
 
     output.on("close", resolve);
     output.on("error", reject);

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -389,6 +389,183 @@ test("checkSakuraScore falls back to a product URL search after an itemsearch pa
   });
 });
 
+test("checkSakuraScore retries ASIN itemsearch after an ambiguous product URL search", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0FPWXKNCK",
+    productUrl: "https://www.amazon.co.jp/dp/B0FPWXKNCK",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      if (calls.length === 2) {
+        return {
+          ok: false,
+          code: "parse_error",
+          message: "Could not locate the requested product in Sakura Checker results.",
+        };
+      }
+
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: "4.99",
+          suffix: "/5",
+        },
+        verdict: {
+          kind: "text-verdict",
+          lines: ["蜷域ｼ", "繧ｵ繧ｯ繝ｩ蠎ｦ 0%"],
+        },
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "text");
+  assert.equal(result.score.value, "4.99");
+  assert.deepEqual(calls, [
+    {
+      asin: "B0FPWXKNCK",
+      sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjBGUFdYS05DSw==",
+    },
+    {
+      asin: "B0FPWXKNCK",
+      sourceUrl: "https://sakura-checker.jp/search/B0FPWXKNCK/",
+      urlSearchProductUrl: "https://www.amazon.co.jp/dp/B0FPWXKNCK",
+    },
+    {
+      asin: "B0FPWXKNCK",
+      sourceUrl: "https://sakura-checker.jp/itemsearch/?word=QjBGUFdYS05DSw==",
+    },
+  ]);
+});
+
+test("checkSakuraScore prefers a detail page score after product URL search returns only a percent score", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0FPWXKNCK",
+    productUrl: "https://www.amazon.co.jp/dp/B0FPWXKNCK",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      if (calls.length === 2) {
+        return {
+          ok: true,
+          score: {
+            kind: "visual-image",
+            images: [{ src: "data:image/png;base64,PERCENT", alt: "9" }],
+            suffix: "%",
+          },
+          verdict: null,
+        };
+      }
+
+      assert.equal(options.sourceUrl, "https://sakura-checker.jp/search/B0FPWXKNCK/");
+      assert.equal(options.urlSearchProductUrl, undefined);
+      return {
+        ok: true,
+        score: {
+          kind: "text",
+          value: "4.99",
+          suffix: "/5",
+        },
+        verdict: {
+          kind: "text-verdict",
+          lines: ["蜷域ｼ", "繧ｵ繧ｯ繝ｩ蠎ｦ 9%"],
+        },
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "text");
+  assert.equal(result.score.value, "4.99");
+  assert.equal(result.score.suffix, "/5");
+  assert.deepEqual(calls.map((call) => call.sourceUrl), [
+    "https://sakura-checker.jp/itemsearch/?word=QjBGUFdYS05DSw==",
+    "https://sakura-checker.jp/search/B0FPWXKNCK/",
+    "https://sakura-checker.jp/search/B0FPWXKNCK/",
+  ]);
+});
+
+test("checkSakuraScore keeps a percent score when the detail page retry fails", async () => {
+  apiClient.__testing.reset();
+  const calls = [];
+
+  const result = await apiClient.checkSakuraScore({
+    asin: "B0MODERN42",
+    productUrl: "https://www.amazon.co.jp/dp/B0MODERN42",
+    forceRefresh: true,
+    fetchRenderedScoreImpl: async (options) => {
+      calls.push(options);
+
+      if (calls.length === 1) {
+        return {
+          ok: false,
+          code: "url_search_required",
+          message: "Sakura Checker asked for an Amazon product URL search.",
+        };
+      }
+
+      if (calls.length === 2) {
+        return {
+          ok: true,
+          score: {
+            kind: "visual-image",
+            images: [{ src: "data:image/png;base64,PERCENT", alt: "safe" }],
+            suffix: "%",
+          },
+          verdict: null,
+        };
+      }
+
+      return {
+        ok: false,
+        code: "parse_error",
+        message: "Could not locate a rendered Sakura Checker score.",
+      };
+    },
+    waitImpl: async () => {},
+    randomImpl: () => 0,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.kind, "visual-image");
+  assert.equal(result.score.suffix, "%");
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls.map((call) => call.sourceUrl), [
+    "https://sakura-checker.jp/itemsearch/?word=QjBNT0RFUk40Mg==",
+    "https://sakura-checker.jp/search/B0MODERN42/",
+    "https://sakura-checker.jp/search/B0MODERN42/",
+  ]);
+});
+
 test("checkSakuraScore uses the provided product URL when itemsearch parsing fails", async () => {
   apiClient.__testing.reset();
   const calls = [];
@@ -468,7 +645,7 @@ test("checkSakuraScore returns the fallback error when URL-search retry also fai
   assert.equal(calls.length, 2);
 });
 
-test("checkSakuraScore stops after one fallback when URL-search retry still requires a product URL", async () => {
+test("checkSakuraScore stops after the ASIN itemsearch retry still requires a product URL", async () => {
   apiClient.__testing.reset();
   const calls = [];
 
@@ -490,7 +667,12 @@ test("checkSakuraScore stops after one fallback when URL-search retry still requ
 
   assert.equal(result.ok, false);
   assert.equal(result.code, "url_search_required");
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls.map((call) => call.sourceUrl), [
+    "https://sakura-checker.jp/itemsearch/?word=QjBCSkRZNkQxVw==",
+    "https://sakura-checker.jp/search/B0BJDY6D1W/",
+    "https://sakura-checker.jp/itemsearch/?word=QjBCSkRZNkQxVw==",
+  ]);
 });
 
 test("checkSakuraScore deduplicates concurrent requests for the same ASIN", async () => {

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -228,6 +228,44 @@ test("extractRenderedScore waits for hidden requested legacy cards before using 
   assert.equal(result.retryable, true);
 });
 
+test("extractRenderedScore waits when the only requested legacy card is hidden", () => {
+  const hiddenTargetImage = fixtures.sampleImageTag.replace(
+    'alt="score"',
+    'alt="hidden-target"'
+  );
+  const document = parseDocument(`
+    <!DOCTYPE html>
+    <html lang="ja">
+      <body>
+        <div class="item-review-wrap">
+          <div class="item-image">
+            <a href="https://www.amazon.co.jp/dp/B0TARGET42/?tag=sakurachecker-22"></a>
+          </div>
+          <div class="item-info hidden-target" style="display: none;">
+            <div class="item-review-box">
+              <div class="item-review-after">
+                <p class="item-rating"><span>${hiddenTargetImage}</span>/5</p>
+              </div>
+              <div class="item-review-level">
+                <p class="item-rv-score">Hidden target score</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sakuraBlock">
+          ${fixtures.modernSakuraAlertMarkup}
+          ${fixtures.modernSakuraRatingMarkup}
+        </div>
+      </body>
+    </html>
+  `);
+  const result = renderedParser.extractRenderedScore(document, "B0TARGET42");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "not_ready");
+  assert.equal(result.retryable, true);
+});
+
 test("extractRenderedScore falls back to the modern summary when wrapper-scoped legacy siblings are ambiguous", () => {
   const document = parseDocument(fixtures.ambiguousWrapperWithModernHtml);
   const result = renderedParser.extractRenderedScore(document, "B095JGJCC7");

--- a/tests/rendered-score-parser.test.js
+++ b/tests/rendered-score-parser.test.js
@@ -122,6 +122,112 @@ test("extractRenderedScore preserves the best legacy card when wrapper-scoped si
   assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level01.png");
 });
 
+test("extractRenderedScore uses the visible card when hidden comparison cards share the requested wrapper", () => {
+  const hiddenComparisonImage = fixtures.sampleImageTag.replace(
+    'alt="score"',
+    'alt="hidden-score"'
+  );
+  const visibleTargetImage = fixtures.sampleImageTag.replace(
+    'alt="score"',
+    'alt="visible-target"'
+  );
+  const document = parseDocument(`
+    <!DOCTYPE html>
+    <html lang="ja">
+      <body>
+        <div class="item-review-wrap">
+          <div class="item-image">
+            <a href="https://www.amazon.co.jp/dp/B0TARGET42/?tag=sakurachecker-22"></a>
+          </div>
+          <div class="item-info hidden-comparison" style="display: none;">
+            <div class="item-review-box">
+              <div class="item-review-after">
+                <p class="item-rating"><span>${hiddenComparisonImage}</span>/5</p>
+              </div>
+              <div class="item-review-level">
+                <p class="item-rv-lv"><img src="/images/rv_level04.png" alt="hidden verdict"></p>
+                <p class="item-rv-score">Hidden comparison score</p>
+              </div>
+            </div>
+          </div>
+          <div class="item-info visible-target">
+            <div class="item-review-box">
+              <div class="item-review-after">
+                <p class="item-rating"><span>${visibleTargetImage}</span>/5</p>
+              </div>
+              <div class="item-review-level">
+                <p class="item-rv-lv"><img src="/images/rv_level01.png" alt="visible verdict"></p>
+                <p class="item-rv-score">Visible target score</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  `);
+  const result = renderedParser.extractRenderedScore(document, "B0TARGET42");
+
+  assert.equal(result.ok, true);
+  assert.equal(result.score.suffix, "/5");
+  assert.deepEqual(
+    result.score.images.map((image) => image.alt),
+    ["visible-target"]
+  );
+  assert.equal(result.verdict.image.src, "https://sakura-checker.jp/images/rv_level01.png");
+});
+
+test("extractRenderedScore waits for hidden requested legacy cards before using a modern summary", () => {
+  const hiddenTargetImage = fixtures.sampleImageTag.replace(
+    'alt="score"',
+    'alt="hidden-target"'
+  );
+  const hiddenComparisonImage = fixtures.sampleImageTag.replace(
+    'alt="score"',
+    'alt="hidden-comparison"'
+  );
+  const document = parseDocument(`
+    <!DOCTYPE html>
+    <html lang="ja">
+      <body>
+        <div class="item-review-wrap">
+          <div class="item-image">
+            <a href="https://www.amazon.co.jp/dp/B0TARGET42/?tag=sakurachecker-22"></a>
+          </div>
+          <div class="item-info hidden-target" style="display: none;">
+            <div class="item-review-box">
+              <div class="item-review-after">
+                <p class="item-rating"><span>${hiddenTargetImage}</span>/5</p>
+              </div>
+              <div class="item-review-level">
+                <p class="item-rv-score">Hidden target score</p>
+              </div>
+            </div>
+          </div>
+          <div class="item-info hidden-comparison" style="display: none;">
+            <div class="item-review-box">
+              <div class="item-review-after">
+                <p class="item-rating"><span>${hiddenComparisonImage}</span>/5</p>
+              </div>
+              <div class="item-review-level">
+                <p class="item-rv-score">Hidden comparison score</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sakuraBlock">
+          ${fixtures.modernSakuraAlertMarkup}
+          ${fixtures.modernSakuraRatingMarkup}
+        </div>
+      </body>
+    </html>
+  `);
+  const result = renderedParser.extractRenderedScore(document, "B0TARGET42");
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "not_ready");
+  assert.equal(result.retryable, true);
+});
+
 test("extractRenderedScore falls back to the modern summary when wrapper-scoped legacy siblings are ambiguous", () => {
   const document = parseDocument(fixtures.ambiguousWrapperWithModernHtml);
   const result = renderedParser.extractRenderedScore(document, "B095JGJCC7");


### PR DESCRIPTION
## Summary

- Bump the extension version to `2.1.7`.
- Strengthen Sakura Checker fallback flow so ambiguous product URL searches can recover via ASIN/detail-page retries.
- Prefer `/5` detail-page scores over earlier `%` Sakura-degree summaries when both are available.
- Update rendered score parsing to select the visible target card when Sakura Checker renders hidden comparison cards in the same product wrapper.

## Root Cause

Some Sakura Checker pages render multiple hidden comparison cards alongside the target product card. The extension could treat an earlier `%` Sakura-degree summary as a successful result before the visible `/5` product score was selected, or fail to identify the target after URL-search fallback.

## Validation

- `node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js` passed: 78/78.
- Real Chromium extension E2E passed for the original Keychron ASIN `B0FPWXKNCK` with `4.99 /5`.
- Real Chromium extension E2E passed for all 12 additional requested Amazon product URLs, each rendering a `/5` Sakura Checker panel and the expected Sakura Checker detail link.

Screenshots from the final batch run are available locally under `output/playwright/final-batch-e2e-*.png`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Sakuraスコア取得のフォールバック強化** - パーセント形式（%）のスコアが返された場合に詳細ページ（/5）のスコアを自動的に再取得する処理を追加し、曖昧なURL検索からの復帰を可能にした。

- **複数カード存在時の表示カード優先取得** - DOM要素の表示/非表示状態（display:none、visibility:hidden、opacity:0など）を判定する処理を追加し、同一ラッパー内の隠れた比較カードではなく、画面に表示されているターゲットカードのスコアを正確に抽出するようにした。

- **テストカバレッジ拡充** - フォールバック/リトライ挙動とDOM可視性判定に関する新しいテストケースを追加し、改善された機能の動作確認を強化した。

- **セキュリティ更新** - archiver（^7.0.1→^8.0.0）とplaywright（^1.58.2→^1.60.0）を更新し、脆弱性がないことを確認した上で依存パッケージのセキュリティを向上させた。

- **バージョンアップ** - 拡張機能バージョンを2.1.6から2.1.7に更新した。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->