### PR TITLE
[codex] Update GitHub Actions to v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.version-check.outputs.version-changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v4 to v6
- Update `actions/setup-node` from v4 to v6

## Why

GitHub Actions is warning that JavaScript actions running on Node.js 20 are deprecated and will be forced to Node.js 24. Updating these official actions to v6 moves the workflow onto the current supported major versions.

## Validation

- Ran `git diff --check`
- Confirmed the workflow only references `actions/checkout@v6` and `actions/setup-node@v6`