### PR TITLE
fix: unblock Chrome Web Store release validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run release validation without uploading to the Chrome Web Store
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -63,30 +69,32 @@ jobs:
           fi
 
       - name: Setup Node.js
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Install Playwright Chromium
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npx playwright install --with-deps chromium
 
       - name: Run tests
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run test:deploy
 
       - name: Create extension zip
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run zip
 
       - name: Upload to Chrome Web Store
-        if: steps.version-check.outputs.version-changed == 'true'
+        if: >-
+          steps.version-check.outputs.version-changed == 'true' &&
+          (github.event_name != 'workflow_dispatch' || inputs.dry_run == false)
         env:
           CHROME_EXTENSION_ZIP_PATH: extension.zip
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,9 +83,9 @@ jobs:
         if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npx playwright install --with-deps chromium
 
-      - name: Run tests
+      - name: Run deterministic tests
         if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
-        run: npm run test:deploy
+        run: npm test
 
       - name: Create extension zip
         if: steps.version-check.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -46,14 +46,16 @@ The workflow now calls the Chrome Web Store API directly so upload failures incl
 
 1. Update `package.json` to the release version.
 2. Run `npm ci`, then install the required browser with `npx playwright install chromium`.
-3. Run `npm run test:deploy`; `package.json` defines the current release validation suite.
+3. Run `npm run test:deploy` locally; this full release validation is required, and `package.json` defines the current suite.
 4. Run `npm run zip` to sync `manifest.json` and generate `extension.zip`.
 5. Merge the version bump commit into `main`.
 6. The `Deploy to Chrome Web Store` workflow runs automatically.
-7. If the pushed `package.json` version differs from the version at the start of the push, the workflow tests, packages, uploads, and submits the extension for public review.
+7. If the pushed `package.json` version differs from the version at the start of the push, the workflow reruns deterministic tests with `npm test`, packages, uploads, and submits the extension for public review.
 8. Wait for the workflow to finish. Verify that the workflow and upload/publish step succeeded, confirm the final Chrome Web Store status is submitted or under review, and record the workflow run URL and final status in the release report.
 
 Pushes to `main` without a net `package.json` version change across the pushed commit range are complete only when the workflow reports the explicit successful skip; no store submission is expected.
+
+GitHub-hosted Ubuntu runners cannot execute the Sakura Checker live or extension E2E checks because `sakura-checker.jp` blocks their requests with HTTP 403 (`Service unavailable` / `The request is blocked`). Therefore, the required live and E2E checks remain part of the local `npm run test:deploy` release validation, while GitHub Actions reruns deterministic tests and packaging only. A manually dispatched workflow with `dry_run` enabled validates the hosted deterministic-test and packaging path without uploading to the Chrome Web Store.
 
 ## Local packaging
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "サクラチェッカー表示 for Amazon.co.jp",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Amazon.co.jpの商品ページで、サクラチェッカーの評価をその場で確認。別タブで調べる手間なく、購入判断をすばやくサポートします。",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "archiver": "^8.0.0",
         "linkedom": "^0.18.13",
-        "playwright": "^1.60.0"
+        "playwright": "^1.62.1"
       },
       "engines": {
         "node": ">=20.19 <21 || >=22"
@@ -755,35 +755,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-display-sakurachecker",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "MIT",
       "devDependencies": {
         "archiver": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "archiver": "^8.0.0",
         "linkedom": "^0.18.13",
-        "playwright": "^1.62.1"
+        "playwright": "^1.60.0"
       },
       "engines": {
         "node": ">=20.19 <21 || >=22"
@@ -755,35 +755,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "archiver": "^8.0.0",
     "linkedom": "^0.18.13",
-    "playwright": "^1.60.0"
+    "playwright": "^1.62.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "archiver": "^8.0.0",
     "linkedom": "^0.18.13",
-    "playwright": "^1.62.1"
+    "playwright": "^1.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-display-sakurachecker",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Chrome extension that shows Sakura Checker score images on Amazon.co.jp product pages.",
   "scripts": {
     "test": "node --test tests/asin-utils.test.js tests/rendered-score-parser.test.js tests/rendered-score-client.test.js tests/api-client.test.js tests/background-flow.test.js tests/content-flow.test.js",

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -20,7 +20,7 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function formatFailure(asin, result, error) {
+function formatFailure(asin, result, error, diagnostics) {
   const parts = [`ASIN ${asin} live smoke failed.`];
 
   if (result) {
@@ -37,6 +37,10 @@ function formatFailure(asin, result, error) {
 
   if (error) {
     parts.push(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (diagnostics) {
+    parts.push(`Page: ${JSON.stringify(diagnostics)}`);
   }
 
   return parts.join(" ");
@@ -94,23 +98,27 @@ async function waitForRenderedScore(page, asin) {
 async function runLiveSmokeWithRetry(asin) {
   let lastResult = null;
   let lastError = null;
+  let lastDiagnostics = null;
 
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
     let browser = null;
+    let page = null;
+    let responseStatus = null;
 
     try {
       browser = await chromium.launch({ headless: true });
-      const page = await browser.newPage({
+      page = await browser.newPage({
         locale: "ja-JP",
         userAgent:
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
           "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
       });
 
-      await page.goto(`https://sakura-checker.jp/search/${asin}/`, {
+      const response = await page.goto(`https://sakura-checker.jp/search/${asin}/`, {
         waitUntil: "domcontentloaded",
         timeout: renderTimeoutMs,
       });
+      responseStatus = response ? response.status() : null;
 
       const result = await waitForRenderedScore(page, asin);
       lastResult = result;
@@ -128,8 +136,31 @@ async function runLiveSmokeWithRetry(asin) {
     } catch (error) {
       lastError = error;
 
+      if (page) {
+        try {
+          const bodyText = await page.locator("body").innerText({ timeout: 1000 });
+          lastDiagnostics = {
+            status: responseStatus,
+            url: page.url(),
+            title: await page.title(),
+            body: bodyText.replace(/\s+/g, " ").slice(0, 500),
+          };
+        } catch (diagnosticError) {
+          lastDiagnostics = {
+            status: responseStatus,
+            url: page.url(),
+            error:
+              diagnosticError instanceof Error
+                ? diagnosticError.message
+                : String(diagnosticError),
+          };
+        }
+      }
+
       if (attempt === retryDelaysMs.length) {
-        throw new Error(formatFailure(asin, lastResult, lastError), { cause: error });
+        throw new Error(formatFailure(asin, lastResult, lastError, lastDiagnostics), {
+          cause: error,
+        });
       }
 
       await delay(retryDelaysMs[attempt]);


### PR DESCRIPTION
## Root cause

The 2.1.8 release workflow failed before packaging or upload because both Sakura Checker live smoke cases returned HTTP 403 from GitHub-hosted Ubuntu runners. Diagnostic evidence showed `Service unavailable` / `The request is blocked`. The same failure reproduced with Playwright 1.62.1 and 1.60.0, while local macOS validation remained green, ruling out the dependency update and parser as the cause.

## Changes

- keep full unit + live + unpacked-extension E2E release validation mandatory via local `npm run test:deploy`
- rerun deterministic `npm test` on the GitHub-hosted deployment runner, where the upstream live service is unavailable
- add a safe manual `dry_run` path that tests hosted install, deterministic validation, and packaging without upload
- add bounded HTTP status, URL, title, and body diagnostics to future live failures
- document the hosted-runner 403 constraint and validation split
- bump the unpublished failed release from 2.1.8 to 2.1.9 to retrigger deployment

## Verification

### Local, serial
- deterministic tests: 77/77 passed, 0 failed, 0 skipped
- live tests: 2/2 passed, 0 failed, 0 skipped
- unpacked-extension E2E: passed
- both audits: 0 vulnerabilities
- ZIP generation/version sync: passed at 2.1.9
- `git diff --check`: passed

### GitHub-hosted dry-run
- run: https://github.com/big-mon/amazon-display-sakurachecker/actions/runs/31329984063
- `npm ci`: passed
- deterministic tests: 77/77 passed
- ZIP generation/version sync: passed
- Chrome Web Store upload: intentionally skipped

## Review

Independent acceptance review approved the exact candidate with no defects. Reviewed base-relative fingerprint: `67403487def83d20e9f34fe914181a805234543f5d8a4b3b2aabc151aaffe9e0`.

## Release effect

Merging changes the version on `main` from 2.1.8 to 2.1.9. The deployment workflow is expected to run deterministic validation, package the extension, upload it, and submit it for Chrome Web Store review.